### PR TITLE
simplified new module creation

### DIFF
--- a/bin/opencanary.tac
+++ b/bin/opencanary.tac
@@ -7,46 +7,7 @@ from twisted.internet.protocol import Factory
 
 from opencanary.config import config
 from opencanary.logger import getLogger
-from opencanary.modules.http import CanaryHTTP
-from opencanary.modules.ftp import CanaryFTP
-from opencanary.modules.ssh import CanarySSH
-from opencanary.modules.telnet import Telnet
-from opencanary.modules.httpproxy import HTTPProxy
-from opencanary.modules.mysql import CanaryMySQL
-from opencanary.modules.mssql import MSSQL
-from opencanary.modules.ntp import CanaryNtp
-from opencanary.modules.tftp import CanaryTftp
-from opencanary.modules.vnc import CanaryVNC
-from opencanary.modules.sip import CanarySIP
-
-#from opencanary.modules.example0 import CanaryExample0
-#from opencanary.modules.example1 import CanaryExample1
-
-MODULES = [Telnet, CanaryHTTP, CanaryFTP, CanarySSH, HTTPProxy, CanaryMySQL,
-           MSSQL, CanaryVNC, CanaryTftp, CanaryNtp, CanarySIP]
-           #CanaryExample0, CanaryExample1]
-try:
-    #Module needs RDP, but the rest of OpenCanary doesn't
-    from opencanary.modules.rdp import CanaryRDP
-    MODULES.append(CanaryRDP)
-except ImportError:
-    pass
-
-
-try:
-    #Module need Scapy, but the rest of OpenCanary doesn't
-    from opencanary.modules.snmp import CanarySNMP
-    MODULES.append(CanarySNMP)
-except ImportError:
-    pass
-
-# NB: imports below depend on inotify, only available on linux
-import sys
-if sys.platform.startswith("linux"):
-    from opencanary.modules.samba import CanarySamba
-    from opencanary.modules.portscan import CanaryPortscan
-    MODULES.append(CanarySamba)
-    MODULES.append(CanaryPortscan)
+from opencanary.modules import CanaryServices
 
 logger = getLogger(config)
 
@@ -59,7 +20,7 @@ def logMsg(msg):
 
 application = service.Application("opencanaryd")
 
-for module in MODULES:
+for module in CanaryServices:
     # skip if not enabled
     if not config.moduleEnabled(module.NAME):
         continue

--- a/bin/opencanary.tac
+++ b/bin/opencanary.tac
@@ -81,7 +81,7 @@ for module in MODULES:
 
     # start modules
     try:
-        if module in [CanarySamba, CanaryPortscan]:
+        if hasattr(loadmod, 'startYourEngines'):
             loadmod.startYourEngines()
             logMsg("Start module %s" % (module.NAME))
             continue

--- a/opencanary/modules/__init__.py
+++ b/opencanary/modules/__init__.py
@@ -1,9 +1,25 @@
 import sys
 import warnings
-import os.path
+import os
 from pkg_resources import resource_filename
 
 from opencanary.honeycred import *
+
+__all__ = ['CanaryServices', 'CanaryService']
+
+# attempt to import all modules in the directory
+modpath=os.path.dirname(__file__)
+modules = [ f[:-3] for f in os.listdir(modpath) if f[-3:]=='.py' and f[0]!='_'
+                 and os.path.isfile(os.path.join(modpath, f))]
+for module in modules:
+    try:
+        __import__(module, globals(), locals())
+    except ImportError:
+        continue
+
+# list of canary services
+CanaryServices = []
+
 
 class CanaryService(object):
     NAME = 'baseservice'
@@ -17,6 +33,8 @@ class CanaryService(object):
         self.creds = config.getVal("%s.honeycreds" % self.NAME, [])
         if self.creds:
             self.honeyCredHook = buildHoneyCredHook(self.creds)
+
+        CanaryServices.append(self)
 
     @classmethod
     def resource_dir(klass):
@@ -77,6 +95,8 @@ if sys.platform.startswith("linux"):
     import datetime
     import os
 
+    __all__.append('FileSystemWatcher')
+    
     class FileSystemWatcher(object):
 
         def __init__(self, fileName=None):


### PR DESCRIPTION
I added code to modules/__init__.py to dynamically build a list of CanaryServices based on the modules installed in the directory and then changed opencanary.tac to remove all the places where modules were listed by name and replaced them with programatic selection.

This should make it possible to add a new module by merely creating a python module that builds any subclass of CanaryService.