### PR TITLE
Extended Samba 4 VFS audit logging support

### DIFF
--- a/opencanary/modules/samba.py
+++ b/opencanary/modules/samba.py
@@ -15,7 +15,7 @@ if sys.platform.startswith("linux"):
 
         def handleLines(self, lines=None):
             #samba4 re
-            audit_re = re.compile(r'.*smbd_audit: (.*)')
+            audit_re = re.compile(r'.*smbd_audit: ([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|]([^|]+?)[|](.*)')
 
             #samba 3 re
             #audit_re = re.compile(r'.*smbd\[[0-9]+\]: (.*)')
@@ -23,7 +23,7 @@ if sys.platform.startswith("linux"):
                     matches = audit_re.match(line)
                     (user,remoteIP,localIP,remoteName,shareName,
                     localName,smbVer,smbArch,timeStamp,domainName,
-                    auditAction,auditStatus,fileName) = matches.group(1).split('|')
+                    auditAction,auditStatus,fileName) = matches.groups()
 
                     data = {}
                     data['src_host'] = remoteIP


### PR DESCRIPTION
With this fully backward-compatible change, the Samba module will not crash anymore when additional fields are found within the audit log file.

This allows for example the following Samba configuration, for further forensic details:

 vfs objects = fake_perms full_audit
 full_audit: success = connect pread disconnect
 full_audit: failure = open unlink

This can be perfected, as it currently inserts any additional field within the FILENAME field, for example a failed open-to-write VFS call for Filename.txt (open flag 'w') will log "w|Filename.txt".