### PR TITLE
Bumped cryptography library to 3.0

### DIFF
--- a/opencanary/modules/ssh.py
+++ b/opencanary/modules/ssh.py
@@ -342,7 +342,7 @@ def getDSAKeys():
 
     if not (os.path.exists(public_key) and os.path.exists(private_key)):
         ssh_key = dsa.generate_private_key(
-            key_size=2048,
+            key_size=1024,
             backend=default_backend())
         public_key_string = ssh_key.public_key().public_bytes(
             serialization.Encoding.OpenSSH,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import opencanary
 requirements = [
     'Twisted==19.10.0',
     'pyasn1==0.4.5',
-    'cryptography==2.5.0',
+    'cryptography==3.0',
     'simplejson==3.16.0',
     'requests==2.21.0',
     'zope.interface==4.6.0',


### PR DESCRIPTION
Bumped to the latest version so we don't conflict with rdpy #86

There was a recent [change](https://github.com/pyca/cryptography/commit/0f8626093cb90d7db97b37505a021b7a65ad5aeb) to the validation of DSA keys where cryptography will now raise an error if the keys not [exactly 1024 bits](https://github.com/pyca/cryptography/blob/3.0/src/cryptography/hazmat/primitives/serialization/ssh.py#L333).