### PR TITLE
Exit with error when no config file was loaded

### DIFF
--- a/bin/opencanaryd
+++ b/bin/opencanaryd
@@ -11,26 +11,16 @@ function usage() {
     echo -e "\t\t--dev\tRun the opencanaryd process in the foreground"
     echo -e "\t\t--stop\tStops the opencanaryd process"
     echo -e "\t\t--usermodule\tRun opencanaryd in foreground with only usermodules enabled"
-    echo -e "\t\t--copyconfig\tCreates a default config file at ${HOME}/.opencanary.conf"
+    echo -e "\t\t--copyconfig\tCreates a default config file at /etc/opencanaryd/opencanary.conf"
     echo -e "\t\t--"
     echo -e "\t\t--help\tThis help\n"
 
 }
 
 if [ "${cmd}" == "--start" ]; then
-    if [ ! -f ~/.opencanary.conf -a ! -f opencanary.conf -a ! -f /etc/opencanaryd/opencanary.conf ]; then
-        echo "[e] No config file found, please create one with \"opencanaryd --copyconfig\""
-        exit 1
-    fi
-
     sudo "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
 elif [ "${cmd}" == "--dev" ]; then
-  if [ ! -f ~/.opencanary.conf -a ! -f opencanary.conf -a ! -f /etc/opencanaryd/opencanary.conf ]; then
-      echo "[e] No config file found, please create one with \"opencanaryd --copyconfig\""
-      exit 1
-  fi
-
-  sudo "${DIR}/twistd" -noy "${DIR}/opencanary.tac"
+    sudo "${DIR}/twistd" -noy "${DIR}/opencanary.tac"
 elif [ "${cmd}" == "--usermodule" ]; then
   usermodconf=$(python -c "from __future__ import print_function; from pkg_resources import resource_filename; print(resource_filename('opencanary', 'data/settings-usermodule.json'))")
 
@@ -47,23 +37,18 @@ elif [ "${cmd}" == "--usermodule" ]; then
 elif [ "${cmd}" == "--restart" ]; then
     pid=`sudo cat "${PIDFILE}"`
     sudo kill "$pid"
-    if [ ! -f ~/.opencanary.conf -a ! -f opencanary.conf -a ! -f /etc/opencanaryd/opencanary.conf ]; then
-        echo "[e] No config file found, please create one with \"opencanaryd --copyconfig\""
-        exit 1
-    fi
     sudo "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
-
 elif [ "${cmd}" == "--stop" ]; then
     pid=`sudo cat "${PIDFILE}"`
     sudo kill "$pid"
 elif [ "${cmd}" == "--copyconfig" ]; then
-    if [ -f ~/.opencanary.conf ]; then
-        echo "[e] A config file already exists at ${HOME}/.opencanary.conf, please move it first"
+    if [ -f /etc/opencanaryd/opencanary.conf ]; then
+        echo "A config file already exists at /etc/opencanaryd/opencanary.conf, please move it first"
         exit 1
     fi
     defaultconf=$(python -c "from __future__ import print_function; from pkg_resources import resource_filename; print(resource_filename('opencanary', 'data/settings.json'))")
-    cp "${defaultconf}" ~/.opencanary.conf
-    echo -e "[*] A sample config file is ready (${HOME}/.opencanary.conf)\n"
+    sudo cp "${defaultconf}" /etc/opencanaryd/opencanary.conf
+    echo -e "[*] A sample config file is ready /etc/opencanaryd/opencanary.conf\n"
     echo    "[*] Edit your configuration, then launch with \"opencanaryd --start\""
 else
     usage

--- a/bin/opencanaryd
+++ b/bin/opencanaryd
@@ -47,6 +47,7 @@ elif [ "${cmd}" == "--copyconfig" ]; then
         exit 1
     fi
     defaultconf=$(python -c "from __future__ import print_function; from pkg_resources import resource_filename; print(resource_filename('opencanary', 'data/settings.json'))")
+    sudo mkdir -p /etc/opencanaryd
     sudo cp "${defaultconf}" /etc/opencanaryd/opencanary.conf
     echo -e "[*] A sample config file is ready /etc/opencanaryd/opencanary.conf\n"
     echo    "[*] Edit your configuration, then launch with \"opencanaryd --start\""

--- a/opencanary/config.py
+++ b/opencanary/config.py
@@ -46,6 +46,9 @@ class Config:
                 subprocess.call("cp -r %s /var/tmp/config-err-$(date +%%s)" % fname, shell=True)
             except Exception as e:
                 print("[-] An error occured loading %s (%s)" % (fname, e))
+        if self.__config is None:
+            print('No config file found. Please create one with "opencanaryd --copyconfig"')
+            sys.exit(1)
 
     def moduleEnabled(self, module_name):
         k = "%s.enabled" % module_name.lower()


### PR DESCRIPTION
Issue #99 

The problem seems to be that the default config is created in the users home directory (e.g. `/home/michael/.opencanary.conf`) and [opencanaryd](https://github.com/thinkst/opencanary/blob/fea6e084ef718d0ad09d8e3114631b80aa9663d5/bin/opencanaryd#L21) checks the file exists before starting. But then [starts twistd with sudo](https://github.com/thinkst/opencanary/blob/fea6e084ef718d0ad09d8e3114631b80aa9663d5/bin/opencanaryd#L26).

Because opencanary is now running as root, when it [looks for a config file](https://github.com/thinkst/opencanary/blob/fea6e084ef718d0ad09d8e3114631b80aa9663d5/opencanary/config.py#L33) in the home directory it looks in `/root/.opencanary.conf`

This PR removes the check for a config file from opencanaryd and adds it into config.py.

It also changes the default location for newly created config files to be in `/etc/opencanaryd/opencanary.conf`. I think it's a more standard location, and that seeing as we are running as root, and potentially executing arbitrary code from the config file, there isn't much advantage to having the config file in the users home directory.