### PR TITLE
Fix error page replacement strings and json socket logging

### DIFF
--- a/opencanary/logger.py
+++ b/opencanary/logger.py
@@ -191,7 +191,7 @@ class SocketJSONHandler(SocketHandler):
                 # connection for the next msg, sendall still reports
                 # successful write on a disconnected socket but then
                 # on subsequent writes it fails correctly.
-                self.sock.sendall(s)
+                self.sock.sendall(s.encode("utf-8"))
                 return
             except socket.error:
                 self.sock.close()

--- a/opencanary/modules/http.py
+++ b/opencanary/modules/http.py
@@ -34,8 +34,8 @@ class Error(Resource):
                 .replace(b'<', b'&lt;')\
                 .replace(b'>', b'&gt;')
         return self.error_contents\
-                .replace('[[URL]]', str(path))\
-                .replace('[[BANNER]]', str(self.factory.banner))
+                .replace('[[URL]]', path.decode("utf-8"))\
+                .replace('[[BANNER]]', self.factory.banner.decode("utf-8"))
 
     def render(self, request):
         request.setHeader(b'Server', self.factory.banner)


### PR DESCRIPTION
This is likely only an issue with python 3.6
Before:
![image](https://user-images.githubusercontent.com/5401186/95744880-01cb7d80-0c8c-11eb-9b7c-168a9c96c4a0.png)

After:
![image](https://user-images.githubusercontent.com/5401186/95744853-f5dfbb80-0c8b-11eb-8fc3-0ee85e08ac46.png)
