### PR TITLE
Format 'Canary running!!!' message

### DIFF
--- a/bin/opencanary.tac
+++ b/bin/opencanary.tac
@@ -142,4 +142,5 @@ start_modules.extend(filter(lambda m: config.moduleEnabled(m.NAME), MODULES))
 for klass in start_modules:
     start_mod(application, klass)
 
-logMsg("Canary running!!!")
+msg = 'Canary running!!!'
+logMsg({'logdata': msg})


### PR DESCRIPTION
Other log messages in OpenCanary are usually formatted in JSON as `{"msg": {"logdata": "Added service from class CanaryFTP..."}}`. The **Canary runing!!!** log message, however, is fomatted as `{"msg": "Canary running!!!"}`.

This patch updates the message to be consistent with other messages.