### PR TITLE
Fix inconsistent samba log analysis and consequent missing or broken alerts

### DIFF
--- a/opencanary/modules/samba.py
+++ b/opencanary/modules/samba.py
@@ -12,50 +12,49 @@ if sys.platform.startswith("linux"):
         def __init__(self, logFile=None, logger=None):
             self.logger = logger
             FileSystemWatcher.__init__(self, fileName=logFile)
-                                                                                    
+
         def handleLines(self, lines=None):
-            #samba4 re                                                        
             audit_re = re.compile(r'^.*smbd_audit:.*$')
-                                   
-            for line in lines:        
+
+            for line in lines:
                     matches = audit_re.match(line)
-                                          
+
                     #Skip lines that do not match the correct RegEx pattern
-                    if matches is None:   
-                           continue      
-                                      
+                    if matches is None:
+                           continue
+
                     data = line.split('smbd_audit:',1)[-1].strip().split('|')
-                                           
-                    user = data[0]         
+
+                    user = data[0]
                     srcHost = data[1]
                     dstHost = data[2]
                     srcHostName = data[3]
-                    shareName = data[4]  
+                    shareName = data[4]
                     dstHostName = data[5]
                     smbVersion = data[6]
-                    smbArch = data[7]           
-                    domainName = data[9]       
-                    auditAction = data[10]  
-                    auditStatus = data[11]     
-                    path = data[13]            
-                                           
-                    if user == "":                                   
-                      user = "anonymous"                                                              
-                                                                                                     
-                    data = {}                                                                          
-                    data['src_host'] = srcHost                                                             
-                    data['src_port'] = '-1'                                              
-                    data['dst_host'] = dstHost                                     
-                    data['dst_port'] = 445                                     
+                    smbArch = data[7]
+                    domainName = data[9]
+                    auditAction = data[10]
+                    auditStatus = data[11]
+                    path = data[13]
+
+                    if user == "":
+                      user = "anonymous"
+
+                    data = {}
+                    data['src_host'] = srcHost
+                    data['src_port'] = '-1'
+                    data['dst_host'] = dstHost
+                    data['dst_port'] = 445
                     data['logtype'] =  self.logger.LOG_SMB_FILE_OPEN
                     data['logdata'] = {'USER':user, 'REMOTENAME': srcHostName, 'SHARENAME': shareName,
                                        'LOCALNAME': dstHostName, 'SMBVER': smbVersion, 'SMBARCH': smbArch,
                                        'DOMAIN': domainName, 'AUDITACTION': auditAction,
                                        'STATUS':auditStatus, 'FILENAME': path}
                     self.logger.log(data)
-                                                      
+
     class CanarySamba(CanaryService):
-        NAME = 'smb'                                     
+        NAME = 'smb'
         def __init__(self,config=None, logger=None):                                                                                                                                                                                         
             CanaryService.__init__(self, config=config, logger=logger)                                                                                                                                                                       
             self.audit_file = config.getVal('smb.auditfile', default='/var/log/samba-audit.log')

--- a/opencanary/modules/samba.py
+++ b/opencanary/modules/samba.py
@@ -55,17 +55,17 @@ if sys.platform.startswith("linux"):
 
     class CanarySamba(CanaryService):
         NAME = 'smb'
-        def __init__(self,config=None, logger=None):                                                                                                                                                                                         
-            CanaryService.__init__(self, config=config, logger=logger)                                                                                                                                                                       
+        def __init__(self,config=None, logger=None):
+            CanaryService.__init__(self, config=config, logger=logger)
             self.audit_file = config.getVal('smb.auditfile', default='/var/log/samba-audit.log')
-            self.config = config                                   
-          
+            self.config = config
+
         def startYourEngines(self, reactor=None):
             #create samba run dir, so testparm doesn't error
-            #try:                                                  
-            #    os.stat('/var/run/samba')       
+            #try:
+            #    os.stat('/var/run/samba')
             #except OSError:
             #    os.mkdir('/var/run/samba')
-                                 
+
             fs = SambaLogWatcher(logFile=self.audit_file, logger=self.logger)
             fs.start()

--- a/opencanary/modules/samba.py
+++ b/opencanary/modules/samba.py
@@ -12,50 +12,61 @@ if sys.platform.startswith("linux"):
         def __init__(self, logFile=None, logger=None):
             self.logger = logger
             FileSystemWatcher.__init__(self, fileName=logFile)
-
+                                                                                    
         def handleLines(self, lines=None):
-            #samba4 re
-            audit_re = re.compile(r'.*smbd_audit: ((?:[^|]*\|){12}[^|]*)$')
-
-            #samba 3 re
-            #audit_re = re.compile(r'.*smbd\[[0-9]+\]: (.*)')
-            for line in lines:
+            #samba4 re                                                        
+            audit_re = re.compile(r'^.*smbd_audit:.*$')
+                                   
+            for line in lines:        
                     matches = audit_re.match(line)
-                    
+                                          
                     #Skip lines that do not match the correct RegEx pattern
-                    if matches is None:
-                           continue
-                    (user,remoteIP,localIP,remoteName,shareName,
-                    localName,smbVer,smbArch,timeStamp,domainName,
-                    auditAction,auditStatus,fileName) = matches.group(1).split('|')
-
-                    data = {}
-                    data['src_host'] = remoteIP
-                    data['src_port'] = '-1'
-                    data['dst_host'] = localIP
-                    data['dst_port'] = 445
+                    if matches is None:   
+                           continue      
+                                      
+                    data = line.split('smbd_audit:',1)[-1].strip().split('|')
+                                           
+                    user = data[0]         
+                    srcHost = data[1]
+                    dstHost = data[2]
+                    srcHostName = data[3]
+                    shareName = data[4]  
+                    dstHostName = data[5]
+                    smbVersion = data[6]
+                    smbArch = data[7]           
+                    domainName = data[9]       
+                    auditAction = data[10]  
+                    auditStatus = data[11]     
+                    path = data[13]            
+                                           
+                    if user == "":                                   
+                      user = "anonymous"                                                              
+                                                                                                     
+                    data = {}                                                                          
+                    data['src_host'] = srcHost                                                             
+                    data['src_port'] = '-1'                                              
+                    data['dst_host'] = dstHost                                     
+                    data['dst_port'] = 445                                     
                     data['logtype'] =  self.logger.LOG_SMB_FILE_OPEN
-                    data['logdata'] = {'USER':user, 'REMOTENAME': remoteName, 'SHARENAME': shareName,
-                                       'LOCALNAME': localName, 'SMBVER': smbVer, 'SMBARCH': smbArch,
+                    data['logdata'] = {'USER':user, 'REMOTENAME': srcHostName, 'SHARENAME': shareName,
+                                       'LOCALNAME': dstHostName, 'SMBVER': smbVersion, 'SMBARCH': smbArch,
                                        'DOMAIN': domainName, 'AUDITACTION': auditAction,
-                                       'STATUS':auditStatus, 'FILENAME': fileName}
+                                       'STATUS':auditStatus, 'FILENAME': path}
                     self.logger.log(data)
-
+                                                      
     class CanarySamba(CanaryService):
-        NAME = 'smb'
-        def __init__(self,config=None, logger=None):
-            CanaryService.__init__(self, config=config, logger=logger)
+        NAME = 'smb'                                     
+        def __init__(self,config=None, logger=None):                                                                                                                                                                                         
+            CanaryService.__init__(self, config=config, logger=logger)                                                                                                                                                                       
             self.audit_file = config.getVal('smb.auditfile', default='/var/log/samba-audit.log')
-            self.config = config
-
+            self.config = config                                   
+          
         def startYourEngines(self, reactor=None):
             #create samba run dir, so testparm doesn't error
-            #try:
-            #    os.stat('/var/run/samba')
+            #try:                                                  
+            #    os.stat('/var/run/samba')       
             #except OSError:
             #    os.mkdir('/var/run/samba')
-
+                                 
             fs = SambaLogWatcher(logFile=self.audit_file, logger=self.logger)
             fs.start()
-
-


### PR DESCRIPTION
Previously the srcHost was dstHost and srcHost was blank. Many other logged fields were empty or transposed. Any access to the SMB honeypot would on occasion blow up because the number of variables the result of the split is assigned into didn't match the number of array items resulting from the split.

The regex is simpler and is used solely to identify lines of interest in the audit file.
Now we use an initial split to throw away the log metadata, with a second split on '|' which is assigned to a new object.
We then use the new object to populate a set of distinctly named variables. This might not be the cleanest or most efficient way of doing it, but it does show the assumptions made at the time this code was written and I think also makes it easier to maintain when the log format changes.

I've also removed the Samba 3 support because surely no one uses it?