### PR TITLE
Fix for VNC module - Decode version portion in version string

### DIFF
--- a/opencanary/modules/vnc.py
+++ b/opencanary/modules/vnc.py
@@ -43,7 +43,7 @@ class VNCProtocol(Protocol):
 
     def _send_handshake(self,):
         print('send handshake')
-        version_string = 'RFB {version}\n'.format(version=self.serv_version)
+        version_string = 'RFB {version}\n'.format(version=self.serv_version.decode('utf-8'))
         self.transport.write(version_string.encode('utf-8'))
         self.state = HANDSHAKE_SEND
 


### PR DESCRIPTION
Out of the box, the VNC module won't work properly on python 3.8. If you start it and try to connect you get an error:

```shell
user@ubuntu-2004:~$ vncviewer 192.168.1.108
Not a valid VNC server
```

If you nc to the port you get:
```shell
user@ubuntu-2004:~$ nc 192.168.1.108 5900 -v
Connection to 192.168.1.108 5900 port [tcp/*] succeeded!
RFB b'003.008'
^C
```

With this PR vncviewer works:

```shell
user@ubuntu-2004:~$ nc 192.168.1.108 5900 -v
Connection to 192.168.1.108 5900 port [tcp/*] succeeded!
RFB 003.008
^C
user@ubuntu-2004:~$ vncviewer 192.168.1.108:5900
Connected to RFB server, using protocol version 3.8
Performing standard VNC authentication
Password: 
Authentication failure
```
