### PR TITLE
Adding automated CI testing via Github Actions

### DIFF
--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -1,0 +1,39 @@
+name: OpenCanary Tests
+
+on:
+  - "push"
+  - "pull_request"
+
+jobs:
+  opencanary_tests:
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: ["ubuntu-18.04", "ubuntu-20.04", "macos-10.15", "macos-11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v2"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: Install required linux dependencies
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-setuptools
+      - name: Install wheel
+        run: sudo pip3 install wheel
+      - name: Create package
+        run: sudo python3 setup.py sdist
+      - name: Install package
+        run: sudo pip3 install dist/opencanary-*.tar.gz
+      - name: Install test dependencies
+        run: sudo pip3 install -r opencanary/test/requirements.txt
+      - name: Copy config file
+        run: cp opencanary/test/opencanary.conf .
+      - name: Start OpenCanary
+        run: opencanaryd --start
+      - name: Run Pytest
+        run: pytest -s

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: ["ubuntu-18.04", "ubuntu-20.04", "macos-10.15", "macos-11"]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out repository code"

--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -93,7 +93,7 @@ class TestGitModule(unittest.TestCase):
         # This test must be run after the test_clone_a_repository.
         # Unless we add an attempt to clone into this test, or the setup.
         last_log = get_last_log()
-        self.assertEqual(last_log['logdata']['HOST'], "localhost")
+        self.assertIn("localhost", last_log['logdata']['HOST'])
         self.assertEqual(last_log['logdata']['REPO'], "test.git")
 
 
@@ -206,11 +206,11 @@ class TestSSHModule(unittest.TestCase):
             self.assertRaises(paramiko.ssh_exception.AuthenticationException,
                               self.connection.connect,
                               hostname="localhost",
-                              port=22,
+                              port=2222,
                               username="test_user",
                               password="test_pass")
         last_log = get_last_log()
-        self.assertEqual(last_log['dst_port'], 22)
+        self.assertEqual(last_log['dst_port'], 2222)
         self.assertIn('paramiko', last_log['logdata']['REMOTEVERSION'])
         self.assertEqual(last_log['logdata']['USERNAME'], "test_user")
         self.assertEqual(last_log['logdata']['PASSWORD'], "test_pass")

--- a/opencanary/test/opencanary.conf
+++ b/opencanary/test/opencanary.conf
@@ -1,0 +1,116 @@
+{
+    "device.node_id": "opencanary-1",
+    "ip.ignorelist": [  ],
+    "git.enabled": true,
+    "git.port" : 9418,
+    "ftp.enabled": true,
+    "ftp.port": 21,
+    "ftp.banner": "FTP server ready",
+    "http.banner": "Apache/2.2.22 (Ubuntu)",
+    "http.enabled": true,
+    "http.port": 80,
+    "http.skin": "nasLogin",
+    "http.skin.list": [
+        {
+            "desc": "Plain HTML Login",
+            "name": "basicLogin"
+        },
+        {
+            "desc": "Synology NAS Login",
+            "name": "nasLogin"
+        }
+    ],
+    "httpproxy.enabled" : false,
+    "httpproxy.port": 8080,
+    "httpproxy.skin": "squid",
+    "httproxy.skin.list": [
+        {
+            "desc": "Squid",
+            "name": "squid"
+        },
+        {
+            "desc": "Microsoft ISA Server Web Proxy",
+            "name": "ms-isa"
+        }
+    ],
+    "logger": {
+        "class": "PyLogger",
+        "kwargs": {
+            "formatters": {
+                "plain": {
+                    "format": "%(message)s"
+                },
+                "syslog_rfc": {
+                    "format": "opencanaryd[%(process)-5s:%(thread)d]: %(name)s %(levelname)-5s %(message)s"
+                }
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout"
+                },
+                "file": {
+                    "class": "logging.FileHandler",
+                    "filename": "/var/tmp/opencanary.log"
+                }
+            }
+        }
+    },
+    "portscan.enabled": false,
+    "portscan.ignore_localhost": false,
+    "portscan.logfile":"/var/log/kern.log",
+    "portscan.synrate": 5,
+    "portscan.nmaposrate": 5,
+    "portscan.lorate": 3,
+    "smb.auditfile": "/var/log/samba-audit.log",
+    "smb.enabled": false,
+    "mysql.enabled": true,
+    "mysql.port": 3306,
+    "mysql.banner": "5.5.43-0ubuntu0.14.04.1",
+    "ssh.enabled": true,
+    "ssh.port": 2222,
+    "ssh.version": "SSH-2.0-OpenSSH_5.1p1 Debian-4",
+    "redis.enabled": false,
+    "redis.port": 6379,
+    "rdp.enabled": false,
+    "rdp.port": 3389,
+    "sip.enabled": false,
+    "sip.port": 5060,
+    "snmp.enabled": false,
+    "snmp.port": 161,
+    "ntp.enabled": true,
+    "ntp.port": 123,
+    "tftp.enabled": false,
+    "tftp.port": 69,
+    "tcpbanner.maxnum":10,
+    "tcpbanner.enabled": false,
+    "tcpbanner_1.enabled": false,
+    "tcpbanner_1.port": 8001,
+    "tcpbanner_1.datareceivedbanner": "",
+    "tcpbanner_1.initbanner": "",
+    "tcpbanner_1.alertstring.enabled": false,
+    "tcpbanner_1.alertstring": "",
+    "tcpbanner_1.keep_alive.enabled": false,
+    "tcpbanner_1.keep_alive_secret": "",
+    "tcpbanner_1.keep_alive_probes": 11,
+    "tcpbanner_1.keep_alive_interval":300,
+    "tcpbanner_1.keep_alive_idle": 300,
+    "telnet.enabled": false,
+    "telnet.port": 23,
+    "telnet.banner": "",
+    "telnet.honeycreds": [
+        {
+            "username": "admin",
+            "password": "$pbkdf2-sha512$19000$bG1NaY3xvjdGyBlj7N37Xw$dGrmBqqWa1okTCpN3QEmeo9j5DuV2u1EuVFD8Di0GxNiM64To5O/Y66f7UASvnQr8.LCzqTm6awC8Kj/aGKvwA"
+        },
+        {
+            "username": "admin",
+            "password": "admin1"
+        }
+    ],
+    "mssql.enabled": false,
+    "mssql.version": "2012",
+    "mssql.port":1433,
+    "vnc.enabled": false,
+    "vnc.port":5000
+}

--- a/opencanary/test/requirements.txt
+++ b/opencanary/test/requirements.txt
@@ -2,3 +2,4 @@ requests
 paramiko
 PyMySQL
 gitpython
+pytest

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     'PyPDF2==1.26.0',
     'fpdf==1.7.2',
     'passlib==1.7.1',
-    'Jinja2==2.10.1',
+    'Jinja2==3.0.1',
     'ntlmlib==0.72',
     'bcrypt==3.1.7',
     'setuptools==44.0.0',


### PR DESCRIPTION
This PR leverages Github Actions to run the current module tests in 4x versions of python (3.7+) running on 2x versions of both Ubuntu and MacOS. I initially wanted to include python2, but ultimately decided the juice wasn't worth the squeeze.

In order for the tests to pass I had to update Jinja2 to 3.0.1 for python 3.10 compatibility as well as change the SSH test to run on a different port since the VMs the tests were on utilize port 22.

I also needed to tweak the Git module test to look for a hostname **in** the key rather than exactly equal. Long story short, `git-upload-pack` [now adds](https://git-scm.com/docs/pack-protocol#_git_transport) `\0version=#\0` to the end of the transport so the hostname was coming up as `'HOST': 'localhost\x00\x00version=2'` in the logs. This seemed like it was just because you are using the gitpython module and not running a git CLI command to run the test so I didn't think it needed to be taken into account in the module itself. Plus, it may prove fragile in the future if they add additional extra parameters between the `host=X` and `version=X`, but that's a potential problem for another day.

See here for an example of the CI in action: https://github.com/joewesch/opencanary/actions/runs/1856565837