### PR TITLE
Use sudo only if not running as root

### DIFF
--- a/bin/opencanaryd
+++ b/bin/opencanaryd
@@ -18,6 +18,16 @@ function usage() {
 
 }
 
+# Use sudo when not running as root
+function sudo() {
+  if [ "$EUID" -ne 0 ]; then
+    $(which sudo) $*
+  else
+    # Strip `sudo -E` before running the remaining command
+    ${*:2}
+  fi
+}
+
 if [ "${cmd}" == "--start" ]; then
     sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
 elif [ "${cmd}" == "--dev" ]; then


### PR DESCRIPTION
`sudo` can be skipped in some cases, like when running in a container as root.

Might address https://github.com/thinkst/opencanary/issues/133