### PR TITLE
Set nasLogin titles to all say "DiskStation"

### DIFF
--- a/opencanary/modules/data/http/skin/nasLogin/index.html
+++ b/opencanary/modules/data/http/skin/nasLogin/index.html
@@ -3,7 +3,7 @@
 
 <meta http-equiv="X-UA-Compatible" content="IE=11">
 <meta name="msapplication-TileImage" content="img/icon_tile.png">
-<meta name="application-name" content="Synology RackStation - DemoSite">
+<meta name="application-name" content="Synology DiskStation - DemoSite">
 <meta name="msapplication-TileColor" content="#246BB3">
 <meta name="description" content="Synology DiskStation provides a full-featured network attached storage (NAS) solution to help you manage, backup and share data among Windows, Mac and Linux easily.">
 <meta name="keywords" content="Multitasking,Web Application,Personal Cloud">
@@ -13,7 +13,7 @@
 <link rel="shortcut icon" href="img/icon_dsm_48.png" sizes="48x48">
 <link rel="shortcut icon" href="img/icon_dsm_32.png" sizes="32x32">
 <link rel="shortcut icon" href="img/icon_dsm_16.png" sizes="16x16">
-<title>Synology&nbsp;RackStation</title>
+<title>Synology&nbsp;DiskStation</title>
 <link rel="stylesheet" type="text/css" href="css/ext-all.css">
 <link rel="stylesheet" type="text/css" href="css/xtheme-gray.css">
 <link rel="stylesheet" type="text/css" href="css/ux-all.css">

--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -110,7 +110,7 @@ class TestHTTPModule(unittest.TestCase):
         """
         request = requests.get('http://localhost/')
         self.assertEqual(request.status_code, 200)
-        self.assertIn('Synology RackStation', request.text)
+        self.assertIn('Synology DiskStation', request.text)
         last_log = get_last_log()
         self.assertEqual(last_log['dst_port'], 80)
         self.assertEqual(last_log['logdata']['HOSTNAME'], "localhost")
@@ -125,7 +125,7 @@ class TestHTTPModule(unittest.TestCase):
         # Currently the web server returns 200, but in future it should return
         # a 403 statuse code.
         self.assertEqual(request.status_code, 200)
-        self.assertIn('Synology RackStation', request.text)
+        self.assertIn('Synology DiskStation', request.text)
         last_log = get_last_log()
         self.assertEqual(last_log['dst_port'], 80)
         self.assertEqual(last_log['logdata']['HOSTNAME'], "localhost")
@@ -148,7 +148,7 @@ class TestHTTPModule(unittest.TestCase):
         # Currently the web server returns 200, but in future it should return
         # a 403 status code.
         self.assertEqual(request.status_code, 200)
-        self.assertIn('Synology RackStation', request.text)
+        self.assertIn('Synology DiskStation', request.text)
         last_log = get_last_log()
         self.assertEqual(last_log['dst_port'], 80)
         self.assertEqual(last_log['logdata']['HOSTNAME'], "localhost")


### PR DESCRIPTION
The nasLogin template had inconsistent titles.
The <title> and <meta name="application-name" ...> of the nasLogin skin (index.html)
said "RackStation", but the login screen said "DiskStation".
The two titles where all set to say  "DiskStation"