### PR TITLE
Update shebang to be more general

### DIFF
--- a/bin/opencanaryd
+++ b/bin/opencanaryd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PIDFILE="${DIR}/opencanaryd.pid"
 


### PR DESCRIPTION
Bash is not the default shell in some operating systems. This change makes it possible for any shell to attempt to run the script.