### PR TITLE
Add -E for all sudo invocations

### DIFF
--- a/bin/opencanaryd
+++ b/bin/opencanaryd
@@ -46,12 +46,12 @@ elif [ "${cmd}" == "--usermodule" ]; then
   sudo -E "${DIR}/twistd" -noy "${DIR}/opencanary.tac"
 
 elif [ "${cmd}" == "--restart" ]; then
-    pid=`sudo cat "${PIDFILE}"`
-    sudo kill "$pid"
+    pid=`sudo -E cat "${PIDFILE}"`
+    sudo -E kill "$pid"
     sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
 elif [ "${cmd}" == "--stop" ]; then
-    pid=`sudo cat "${PIDFILE}"`
-    sudo kill "$pid"
+    pid=`sudo -E cat "${PIDFILE}"`
+    sudo -E kill "$pid"
 elif [ "${cmd}" == "--copyconfig" ]; then
     if [ -f /etc/opencanaryd/opencanary.conf ]; then
         echo "A config file already exists at /etc/opencanaryd/opencanary.conf, please move it first"
@@ -62,8 +62,8 @@ elif [ "${cmd}" == "--copyconfig" ]; then
     else
         defaultconf=$(python3 -c "from pkg_resources import resource_filename; print(resource_filename('opencanary', 'data/settings.json'))")
     fi
-    sudo mkdir -p /etc/opencanaryd
-    sudo cp "${defaultconf}" /etc/opencanaryd/opencanary.conf
+    sudo -E mkdir -p /etc/opencanaryd
+    sudo -E cp "${defaultconf}" /etc/opencanaryd/opencanary.conf
     echo -e "[*] A sample config file is ready /etc/opencanaryd/opencanary.conf\n"
     echo    "[*] Edit your configuration, then launch with \"opencanaryd --start\""
 elif [ "${cmd}" == "--version" ]; then


### PR DESCRIPTION
I just noticed that these had not been updated in https://github.com/thinkst/opencanary/pull/173/commits/4c589046e1109a7d8d2b3a96256717b1086c2eb5 and will break the conditional dynamic use of sudo function and possibly other cases where environments might be needed.