### PR TITLE
Updated packaging and tests

### DIFF
--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Install required linux dependencies
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
-          sudo apt-get update
-          sudo apt-get install python3-setuptools
+          sudo pip3 install setuptools>=44.0.0
       - name: Install wheel
         run: sudo pip3 install wheel
       - name: Create package

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     long_description='A low interaction honeypot intended to be run on internal networks.',
     install_requires=requirements,
     license='BSD',
-    packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']), # docs/conf.py is recognized and must be excluded
+    packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']), # docs/conf.py is unintentionally recognized and leads to a doc package
     package_data={
         'opencanary.data': ['**'],
         'opencanary.modules.data': ['**','*/*', '*/*/*', '*/*/*/*', '*/*/*/*/*', '*/*/*/*/*/*', '*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*/*'], # use of the recursive pattern */**/* is available for setuptools>=62.3.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import codecs
 import os.path
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 import sys
 
 PY3 = sys.version_info > (3,)
@@ -57,14 +57,14 @@ setup(
     description='OpenCanary daemon',
     long_description='A low interaction honeypot intended to be run on internal networks.',
     install_requires=requirements,
-    setup_requires=[
-        'setuptools_git'
-    ],
     license='BSD',
-    packages=find_packages(exclude='test'),
+    packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']), # docs/conf.py is recognized and must be excluded
+    package_data={
+        'opencanary.data': ['**'],
+        'opencanary.modules.data': ['**','*/*', '*/*/*', '*/*/*/*', '*/*/*/*/*', '*/*/*/*/*/*', '*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*/*'], # use of the recursive pattern */**/* is available for setuptools>=62.3.1
+    },
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',
-    include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Changes package discovery by setuptools to no longer need git and ensures all CI tests use the minimum requirements