### PR TITLE
FreeBSD port ground work

### DIFF
--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "${{ matrix.python-version }}"
       - name: Install setuptools

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Install required linux dependencies
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
-          sudo apt-get update
-          sudo apt-get install python3-setuptools
+          sudo pip3 install setuptools>=63.2.0
       - name: Install wheel
         run: sudo pip3 install wheel
       - name: Create package

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: ["ubuntu-20.04", "ubuntu-22.04", "macos-11"]
+        os: ["ubuntu-20.04", "ubuntu-22.04", "macos-11", "macos-12"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: ["ubuntu-18.04", "ubuntu-20.04", "macos-11"]
+        os: ["ubuntu-20.04", "ubuntu-22.04", "macos-11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -19,18 +19,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "${{ matrix.python-version }}"
-      - name: Install required linux dependencies
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-        run: |
-          sudo pip3 install setuptools>=63.2.0
+      - name: Install setuptools
+        run: pip3 install setuptools>=63.2.0
       - name: Install wheel
-        run: sudo pip3 install wheel
+        run: pip3 install wheel
       - name: Create package
-        run: sudo python3 setup.py sdist
+        run: python3 setup.py sdist
       - name: Install package
-        run: sudo pip3 install dist/opencanary-*.tar.gz
+        run: pip3 install dist/opencanary-*.tar.gz
       - name: Install test dependencies
-        run: sudo pip3 install -r opencanary/test/requirements.txt
+        run: pip3 install -r opencanary/test/requirements.txt
       - name: Copy config file
         run: cp opencanary/test/opencanary.conf .
       - name: Start OpenCanary

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,11 @@
 recursive-include opencanary/data *
 recursive-include opencanary/modules/data *
+
+recursive-exclude opencanary/test *
+recursive-exclude .github *
+recursive-exclude docs *
+
+exclude Dockerfile.latest
+exclude Dockerfile.*
+exclude docker-compose.yml
+exclude .gitignore

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include opencanary/data *
+recursive-include opencanary/modules/data *

--- a/opencanary/modules/example1.py
+++ b/opencanary/modules/example1.py
@@ -3,7 +3,6 @@ from opencanary.modules import CanaryService
 from twisted.internet.protocol import Protocol
 from twisted.internet.protocol import Factory
 from twisted.application import internet
-from __future__ import print_function
 
 class Example1Protocol(Protocol):
     """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import codecs
 import os.path
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 import sys
 
 
@@ -47,14 +47,14 @@ setup(
     description='OpenCanary daemon',
     long_description='A low interaction honeypot intended to be run on internal networks.',
     install_requires=requirements,
-    setup_requires=[
-        'setuptools_git'
-    ],
     license='BSD',
-    packages=find_packages(exclude='test'),
+    packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']),
+    package_data={
+        'opencanary.data': ['**'],
+        'opencanary.modules.data': ['*/**/*'],
+    },
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',
-    include_package_data=True,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,7 @@ setup(
             'opencanary.test','opencanary.test*'
         ]
     ),
-    package_data={
-        'opencanary.data': ['**'],
-        'opencanary.modules.data': ['**','*/*', '*/*/*', '*/*/*/*', '*/*/*/*/*', '*/*/*/*/*/*', '*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*/*'],
-    },
+    include_package_data = True,
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     long_description='A low interaction honeypot intended to be run on internal networks.',
     install_requires=requirements,
     license='BSD',
+    packages=find_namespace_packages(include=['opencanary']),
     include_package_data = True,
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,6 @@ setup(
     long_description='A low interaction honeypot intended to be run on internal networks.',
     install_requires=requirements,
     license='BSD',
-    packages=find_namespace_packages(
-        exclude=[
-            'docs','docs*'
-            'opencanary.test','opencanary.test*'
-        ]
-    ),
     include_package_data = True,
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,16 @@ setup(
     long_description='A low interaction honeypot intended to be run on internal networks.',
     install_requires=requirements,
     license='BSD',
-    packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']),
-    include_package_data=True,
+    packages=find_namespace_packages(
+        exclude=[
+            'docs','docs*'
+            'opencanary.test','opencanary.test*'
+        ]
+    ),
+    package_data={
+        'opencanary.data': ['**'],
+        'opencanary.modules.data': ['**','*/*', '*/*/*', '*/*/*/*', '*/*/*/*/*', '*/*/*/*/*/*', '*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*', '*/*/*/*/*/*/*/*/*/*/*/*/*'],
+    },
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import codecs
 import os.path
 from setuptools import setup, find_namespace_packages
-import sys
+import glob
 
 
 def read(rel_path):
@@ -51,7 +51,7 @@ setup(
     packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']),
     package_data={
         'opencanary.data': ['**'],
-        'opencanary.modules.data': ['*/**/*'],
+        'opencanary.modules.data': glob.iglob('opencanary/modules/data/**/*', recursive=True),
     },
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import codecs
 import os.path
 from setuptools import setup, find_namespace_packages
-import glob
+import sys
 
 
 def read(rel_path):
@@ -51,7 +51,7 @@ setup(
     packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']),
     package_data={
         'opencanary.data': ['**'],
-        'opencanary.modules.data': glob.iglob('opencanary/modules/data/**/*', recursive=True),
+        'opencanary.modules.data': ['*/**/*'],
     },
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,7 @@ setup(
     install_requires=requirements,
     license='BSD',
     packages=find_namespace_packages(exclude=['docs','docs*','opencanary.test','opencanary.test*']),
-    package_data={
-        'opencanary.data': ['**'],
-        'opencanary.modules.data': ['*/**/*'],
-    },
+    include_package_data=True,
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,12 @@ setup(
     long_description='A low interaction honeypot intended to be run on internal networks.',
     install_requires=requirements,
     license='BSD',
-    packages=find_namespace_packages(include=['opencanary']),
+    packages=find_namespace_packages(
+        exclude=[
+            'docs','docs*'
+            'opencanary.test','opencanary.test*'
+        ]
+    ),
     include_package_data = True,
     scripts=['bin/opencanaryd','bin/opencanary.tac'],
     platforms='any',


### PR DESCRIPTION
Update setup.py so that the FreeBSD autoplist generation can create a correct plist for the FreeBSD port.
Additional changes include

-  a fix for an example file that still had python2 code in
- Update the GitHub Actions workflow to build on not deprecated OS'es and use the new Node16 version of action definitions

One this has landed and has been tagged we can finalise the FreeBSD port of OpenCanary to point at a tagged release and a commit hash