### PR TITLE
Try to get iptables path from $PATH

### DIFF
--- a/opencanary/test/requirements.txt
+++ b/opencanary/test/requirements.txt
@@ -1,5 +1,5 @@
 requests
-paramiko
+paramiko==2.12.0
 PyMySQL
 gitpython
 pytest


### PR DESCRIPTION
It will allow using iptables path from $PATH using `which`. Using /sbin/iptables as a fallback might still be a good idea if no $PATH is set

Docs for `shutil.which`: https://docs.python.org/3/library/shutil.html#shutil.which

it might address https://github.com/thinkst/opencanary/issues/228 if $PATH is correctly set, if it is not set, it can be set explicitly to ensure right path is used.