### PR TITLE
Add rdp

### DIFF
--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get -yq install --no-install-recommends \
 	apt-get autoremove -yq && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install required pip dependencies
-RUN pip install rdpy
 RUN pip install opencanary
 RUN pip install scapy pcapy
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Prerequisites
 
 * Python 2.7, 3.7 (Recommended Python 3.7+)
 * [Optional] SNMP requires the Python library scapy
-* ~[Optional] RDP requires the Python library rdpy~ (this module has been removed; we are currently determining a way forward with this.)
 * [Optional] Samba module needs a working installation of samba
 
 Installation [UBUNTU]

--- a/bin/opencanary.tac
+++ b/bin/opencanary.tac
@@ -22,24 +22,32 @@ from opencanary.modules.sip import CanarySIP
 from opencanary.modules.git import CanaryGit
 from opencanary.modules.redis import CanaryRedis
 from opencanary.modules.tcpbanner import CanaryTCPBanner
+from opencanary.modules.rdp import CanaryRDP
 
 #from opencanary.modules.example0 import CanaryExample0
 #from opencanary.modules.example1 import CanaryExample1
 
 ENTRYPOINT = "canary.usermodule"
-MODULES = [Telnet, CanaryHTTP, CanaryHTTPS, CanaryFTP, CanarySSH, HTTPProxy,
-           CanaryMySQL, MSSQL, CanaryVNC, CanaryTftp, CanaryNtp, CanarySIP,
-           CanaryGit, CanaryTCPBanner, CanaryRedis]
-           #CanaryExample0, CanaryExample1]
-
-if config.moduleEnabled('rdp'):
-    try:
-        #Module needs RDP, but the rest of OpenCanary doesn't
-        from opencanary.modules.rdp import CanaryRDP
-        MODULES.append(CanaryRDP)
-    except ImportError:
-        print("Can't import RDP. Please ensure you have RDP installed.")
-        pass
+MODULES = [
+    CanaryFTP,
+    CanaryGit,
+    CanaryHTTP,
+    CanaryHTTPS,
+    CanaryMySQL,
+    CanaryNtp,
+    CanaryRDP,
+    CanaryRedis,
+    CanarySIP,
+    CanarySSH,
+    CanaryTCPBanner,
+    CanaryTftp,
+    CanaryVNC,
+    HTTPProxy,
+    MSSQL,
+    Telnet,
+    # CanaryExample0,
+    # CanaryExample1,
+]
 
 if config.moduleEnabled('snmp'):
     try:

--- a/opencanary/modules/rdp.py
+++ b/opencanary/modules/rdp.py
@@ -9,8 +9,11 @@ from twisted.internet.protocol import Factory
 class RemoteDesktopProtocol(Protocol):
     """
     A simple service that logs RDP connection attempts
-    and always responds with a negotiation failure
+    and mimics an NLA-enabled RDP server but responds with login failure
     """
+
+    def __init__(self):
+        self.initial_connection = True
 
     def dataReceived(self, data):
         # Decode the data to unicode, so we can search it, and ignore any errors
@@ -19,26 +22,20 @@ class RemoteDesktopProtocol(Protocol):
         # Use regex to extract the username.
         match = re.search(r"mstshash=(?P<username>[a-zA-Z0-9-_@]*)", decoded_data)
         username = match and match.groupdict().get("username")
-
         # Log the connection attempt
         self.factory.log(logdata={"USERNAME": username}, transport=self.transport)
 
-        # Always respond with a negotiation failure, details from
-        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/1b3920e7-0116-4345-bc45-f2c4ad012761
-        # type (1 byte): An 8-bit, unsigned integer that indicates the packet type.
-        # This field MUST be set to 0x03 (TYPE_RDP_NEG_FAILURE).
-        response_type = b"\x03"
-        # flags (1 byte): An 8-bit, unsigned integer that contains protocol flags.
-        # There are currently no defined flags, so the field MUST be set to 0x00.
-        flags = b"\x00"
-        # length (2 bytes): A 16-bit, unsigned integer that specifies the packet size.
-        # This field MUST be set to 0x0008 (8 bytes).
-        length = b"\x00\x08"
-        # failureCode (4 bytes): A 32-bit, unsigned integer that specifies the failure code.
-        # We use SSL_WITH_USER_AUTH_REQUIRED_BY_SERVER
-        failure_code = b"\x00\x00\x00\x06"
-        self.transport.write(response_type + flags + length + failure_code)
-        self.transport.loseConnection()
+        if self.initial_connection:
+            # Respond as an NLA-enabled RDP server
+            self.transport.write(
+                bytes.fromhex("030000130ed000001234000209080002000000")
+            )
+            self.initial_connection = False
+        else:
+            # Always respond with a negotiation failure, details from
+            # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/96327ab4-d43f-4803-9aff-392ce1fc2073
+            self.transport.write(bytes.fromhex("0001000400010000052e"))
+            self.transport.loseConnection()
 
 
 class CanaryRDP(Factory, CanaryService):

--- a/opencanary/modules/rdp.py
+++ b/opencanary/modules/rdp.py
@@ -1,96 +1,42 @@
-from twisted.internet import reactor
-from twisted.internet.protocol import Protocol
-from twisted.internet.protocol import Factory
-from twisted.application import internet
-from rdpy.protocol.rdp.rdp import RDPServerObserver
-from rdpy.protocol.rdp.rdp import ServerFactory
-from rdpy.core import rss
-from rdpy.core.scancode import scancodeToChar
+import re
+
 from opencanary.modules import CanaryService
 
-class RDPObserver(RDPServerObserver):
-    def __init__(self, factory, controller, rssFile):
-        RDPServerObserver.__init__(self, controller)
-        self.factory = factory
-        self.buffer = ""
+from twisted.internet.protocol import Protocol
+from twisted.internet.protocol import Factory
 
-    def onReady(self):
-        domain, username, password = self._controller.getCredentials()
-        hostname = self._controller.getHostname()
-        logdata = {
-            "DOMAIN": domain,
-            "USERNAME": username,
-            "PASSWORD": password,
-            "HOSTNAME": hostname
-        }
-        transport = self._controller.getProtocol().transport
-        us = transport.getHost()
-        peer = transport.getPeer()
-        self.transportlog = {
-            'src_host' : peer.host,
-            'src_port' : peer.port,
-            'dst_host' : us.host,
-            'dst_port' : us.port
-        }
-        self.factory.log(logdata, **self.transportlog)
-        self.doEvent(0)
 
-    def onClose(self):
-        if getattr(self, "transportlog", None):
-            logdata = {"INPUT" : self.buffer}
-            self.factory.log(logdata, **self.transportlog)
+class RemoteDesktopProtocol(Protocol):
+    """
+    A simple service that logs RDP connection attempts.
+    Does not implement Network Level Authentication (NLA)
+    """
 
-    def onKeyEventScancode(self, code, isPressed, isExtended):
-        self.buffer += scancodeToChar(code)
+    def dataReceived(self, data):
+        # Decode the data to unicode, so we can search it, and ignore any errors
+        # caused by bytes that can't be decoded.
+        decoded_data = data.decode(encoding="utf-8", errors="ignore")
+        # Use regex to extract the username.
+        match = re.search(r"mstshash=(?P<username>[a-zA-Z0-9-_@]*)", decoded_data)
+        username = match and match.groupdict().get("username")
 
-    def onKeyEventUnicode(self, code, isPressed):
-        pass
+        # Log the connection attempt
+        self.factory.log(logdata={"USERNAME": username}, transport=self.transport)
 
-    def onPointerEvent(self, x, y, button, isPressed):
-        pass
+        # Always respond with a negotiation failure
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/1b3920e7-0116-4345-bc45-f2c4ad012761
+        self.transport.write(b"0x3 RDP_NEG_FAILURE")
+        self.transport.loseConnection()
 
-    def doEvent(self, i):
-        if i >= len(self.factory.rss) - 1:
-            return
 
-        e = self.factory.rss[i]
-
-        # TODO: handle other events (eg. the screen resize)
-        if e.type.value == rss.EventType.UPDATE:
-            self._controller.sendUpdate(
-                e.event.destLeft.value,
-                e.event.destTop.value,
-                e.event.destRight.value,
-                e.event.destBottom.value,
-                e.event.width.value, e.event.height.value,
-                e.event.bpp.value,
-                e.event.format.value == rss.UpdateFormat.BMP,
-                e.event.data.value)
-
-        t = self.factory.rss[i+1].timestamp.value
-        reactor.callLater(float(t) / 1000.0, self.doEvent, i + 1)
-
-class CanaryRDP(ServerFactory, CanaryService):
-    NAME = 'rdp'
+class CanaryRDP(Factory, CanaryService):
+    NAME = "rdp"
+    protocol = RemoteDesktopProtocol
 
     def __init__(self, config=None, logger=None):
-        ServerFactory.__init__(self, 16, None, None)
         CanaryService.__init__(self, config, logger)
-
-        self.rssFile = self.resource_filename("login.rss")
-        reader = rss.createReader(self.rssFile)
-        self.rss = []
-        while True:
-            e = reader.nextEvent()
-            if e:
-                self.rss.append(e)
-            else:
-                break
-
         self.port = config.getVal("rdp.port", 3389)
         self.logtype = logger.LOG_RDP
 
-    def buildObserver(self, controller, addr):
-        return RDPObserver(self, controller, self.rssFile)
 
 CanaryServiceFactory = CanaryRDP

--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -365,5 +365,53 @@ class TestMySQLModule(unittest.TestCase):
         self.assertEqual(last_log['dst_port'], 3306)
 
 
+class TestRDPModule(unittest.TestCase):
+    """
+    Tests the RDP Server
+    """
+
+    def test_rdp_with_user_cookie(self):
+        """
+        Login to the RDP server and pass the username in the connection request
+        """
+        self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.connection.connect(("localhost", 3389))
+        packet = b""
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+        # TPKT details
+        packet += b"\x03\x00\x00\x33"
+        # ISO connection
+        packet += b"\x2e\xe0\x00\x00\x00\x00\x00"
+        # RDP Cookie
+        packet += b"Cookie: mstshash=test_rdp_user"
+        # Negotiation request
+        packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
+        self.connection.sendall(packet)
+
+        last_log = get_last_log()
+        self.assertEqual(last_log["logdata"]["USERNAME"], "test_rdp_user")
+        self.assertEqual(last_log["dst_port"], 3389)
+
+    def test_rdp_with_user_cookie(self):
+        """
+        Login to the RDP server and pass the username in the connection request
+        """
+        self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.connection.connect(("localhost", 3389))
+        packet = b""
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+        # TPKT details
+        packet += b"\x03\x00\x00\x13"
+        # ISO connection
+        packet += b"\x0e\xe0\x00\x00\x00\x00\x01"
+        # Negotiation request
+        packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
+        self.connection.sendall(packet)
+
+        last_log = get_last_log()
+        self.assertEqual(last_log["logdata"]["USERNAME"], None)
+        self.assertEqual(last_log["dst_port"], 3389)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -387,12 +387,13 @@ class TestRDPModule(unittest.TestCase):
         # Negotiation request
         packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
         self.connection.sendall(packet)
+        time.sleep(1)
 
         last_log = get_last_log()
         self.assertEqual(last_log["logdata"]["USERNAME"], "test_rdp_user")
         self.assertEqual(last_log["dst_port"], 3389)
 
-    def test_rdp_with_user_cookie(self):
+    def test_rdp_connection_with_no_user_details(self):
         """
         Login to the RDP server and pass the username in the connection request
         """
@@ -407,6 +408,7 @@ class TestRDPModule(unittest.TestCase):
         # Negotiation request
         packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
         self.connection.sendall(packet)
+        time.sleep(1)
 
         last_log = get_last_log()
         self.assertEqual(last_log["logdata"]["USERNAME"], None)

--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -395,7 +395,7 @@ class TestRDPModule(unittest.TestCase):
 
     def test_rdp_connection_with_no_user_details(self):
         """
-        Login to the RDP server and pass the username in the connection request
+        Connect to the RDP server, but do not pass a username (e.g. namp scan)
         """
         self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.connection.connect(("localhost", 3389))

--- a/opencanary/test/opencanary.conf
+++ b/opencanary/test/opencanary.conf
@@ -75,7 +75,7 @@
     "ssh.version": "SSH-2.0-OpenSSH_5.1p1 Debian-4",
     "redis.enabled": false,
     "redis.port": 6379,
-    "rdp.enabled": false,
+    "rdp.enabled": true,
     "rdp.port": 3389,
     "sip.enabled": false,
     "sip.port": 5060,


### PR DESCRIPTION
This adds a basic RDP service to OpenCanary which has been [requested](https://github.com/thinkst/opencanary/issues/240) a few times.

We listen on port 3389 (configurable) and whenever a connection comes in, we respond with a [RDP Negotiation Failure](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/1b3920e7-0116-4345-bc45-f2c4ad012761), this failure indicates that the server and the client could not agree on a security protocol as opposed to a failed login.

The advantage of this approach is that it's incredibly simple, and we don't need to import any third party libraries.

The main drawback is that because we don't implement more of the RDP spec (such as tpkt, x224, ssl, network level authentication) we don't capture more details about the connection attempt like the password or hash being used. Which would not be good if we were trying to collect information / statistics about bots on the internet.

However, in the use case of an OpenCanary, we get a high fidelity alert if an attacker tries to connect to it.