### PR TITLE
add ignore codetype

### DIFF
--- a/data/.opencanary.conf
+++ b/data/.opencanary.conf
@@ -1,6 +1,7 @@
 {
     "device.node_id": "opencanary-1",
     "ip.ignorelist": [  ],
+    "logtype.ignorelist": [  ],
     "git.enabled": false,
     "git.port" : 9418,
     "ftp.enabled": true,

--- a/opencanary/data/settings.json
+++ b/opencanary/data/settings.json
@@ -1,6 +1,7 @@
 {
     "device.node_id": "opencanary-1",
     "ip.ignorelist": [  ],
+    "logtype.ignorelist": [  ],
     "git.enabled": false,
     "git.port" : 9418,
     "ftp.enabled": true,

--- a/opencanary/logger.py
+++ b/opencanary/logger.py
@@ -153,7 +153,7 @@ class PyLogger(LoggerBase):
 
         # Check if ignorelist is populated
         self.ignorelist = config.getVal('ip.ignorelist', default='')
-        self.ignorelogtype = config.getVal('logtype.ignorelist', default='')
+        self.logtype_ignorelist = config.getVal('logtype.ignorelist', default='')
 
         self.logger = logging.getLogger(self.node_id)
 
@@ -165,7 +165,6 @@ class PyLogger(LoggerBase):
 
     def log(self, logdata, retry=True):
         logdata = self.sanitizeLog(logdata)
-        
         # Log only if not in ignorelist
         notify = True
         if 'src_host' in logdata:
@@ -174,11 +173,8 @@ class PyLogger(LoggerBase):
                     notify = False
                     break
 
-        if 'logtype' in logdata:
-            for logtype in self.ignorelogtype:
-                if logdata['logtype'] == logtype:
-                    notify = False
-                    break
+        if 'logtype' in logdata and logdata['logtype'] in self.logtype_ignorelist:
+            notify = False
 
         if notify == True:
             self.logger.warn(json.dumps(logdata, sort_keys=True))

--- a/opencanary/logger.py
+++ b/opencanary/logger.py
@@ -153,6 +153,7 @@ class PyLogger(LoggerBase):
 
         # Check if ignorelist is populated
         self.ignorelist = config.getVal('ip.ignorelist', default='')
+        self.ignorelogtype = config.getVal('logtype.ignorelist', default='')
 
         self.logger = logging.getLogger(self.node_id)
 
@@ -164,6 +165,7 @@ class PyLogger(LoggerBase):
 
     def log(self, logdata, retry=True):
         logdata = self.sanitizeLog(logdata)
+        
         # Log only if not in ignorelist
         notify = True
         if 'src_host' in logdata:
@@ -171,6 +173,13 @@ class PyLogger(LoggerBase):
                 if check_ip(logdata['src_host'], ip) == True:
                     notify = False
                     break
+
+        if 'logtype' in logdata:
+            for logtype in self.ignorelogtype:
+                if logdata['logtype'] == logtype:
+                    notify = False
+                    break
+
         if notify == True:
             self.logger.warn(json.dumps(logdata, sort_keys=True))
 

--- a/opencanary/logger.py
+++ b/opencanary/logger.py
@@ -152,8 +152,8 @@ class PyLogger(LoggerBase):
             exit(1)
 
         # Check if ignorelist is populated
-        self.ip_ignorelist = config.getVal('ip.ignorelist', default='')
-        self.logtype_ignorelist = config.getVal('logtype.ignorelist', default='')
+        self.ip_ignorelist = config.getVal('ip.ignorelist', default=[])
+        self.logtype_ignorelist = config.getVal('logtype.ignorelist', default=[])
 
         self.logger = logging.getLogger(self.node_id)
 

--- a/opencanary/logger.py
+++ b/opencanary/logger.py
@@ -152,7 +152,7 @@ class PyLogger(LoggerBase):
             exit(1)
 
         # Check if ignorelist is populated
-        self.ignorelist = config.getVal('ip.ignorelist', default='')
+        self.ip_ignorelist = config.getVal('ip.ignorelist', default='')
         self.logtype_ignorelist = config.getVal('logtype.ignorelist', default='')
 
         self.logger = logging.getLogger(self.node_id)
@@ -168,7 +168,7 @@ class PyLogger(LoggerBase):
         # Log only if not in ignorelist
         notify = True
         if 'src_host' in logdata:
-            for ip in self.ignorelist:
+            for ip in self.ip_ignorelist:
                 if check_ip(logdata['src_host'], ip) == True:
                     notify = False
                     break


### PR DESCRIPTION
allows to ignore logtype (3000,4000, ...) in opencanary.conf to limit alerts. 