### PR TITLE
Automatically disable portscan in Dockerised OpenCanary

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Head over to our step-by-step wiki over [here](https://github.com/thinkst/openca
 
 > Requires [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
 
+NOTE: The portscan module is automatically disabled for Dockerised OpenCanary.
+
 1. Edit the `data/.opencanary.conf` file to enable, disable or customize the services that will run.
 
 1. Edit the `ports` section of the `docker-compose.yml` file to enable/disable the desired ports based on the services you have enabled in the config file.
@@ -160,6 +162,8 @@ Head over to our step-by-step wiki over [here](https://github.com/thinkst/openca
 ## Docker
 
 > Requires [Docker](https://docs.docker.com/get-docker/) installed.
+
+NOTE: The portscan module is automatically disabled for Dockerised OpenCanary. 
 
 1. Edit the `data/.opencanary.conf` file to enable, disable or customize the services that will run.
 

--- a/bin/opencanary.tac
+++ b/bin/opencanary.tac
@@ -10,7 +10,7 @@ from twisted.application import internet
 from twisted.internet.protocol import Factory
 from pkg_resources import iter_entry_points
 
-from opencanary.config import config
+from opencanary.config import config, is_docker
 from opencanary.logger import getLogger
 from opencanary.modules.http import CanaryHTTP
 from opencanary.modules.https import CanaryHTTPS
@@ -67,9 +67,14 @@ if config.moduleEnabled('snmp'):
 import sys
 if sys.platform.startswith("linux"):
     from opencanary.modules.samba import CanarySamba
-    from opencanary.modules.portscan import CanaryPortscan
     MODULES.append(CanarySamba)
-    MODULES.append(CanaryPortscan)
+    if config.moduleEnabled('portscan') and is_docker():
+        # Remove portscan if running in DOCKER (specified in Dockerfile)
+        print("Can't use portscan in Docker. Portscan module disabled.")
+    else:
+        from opencanary.modules.portscan import CanaryPortscan
+        MODULES.append(CanaryPortscan)
+
 
 logger = getLogger(config)
 

--- a/data/.opencanary.conf
+++ b/data/.opencanary.conf
@@ -62,7 +62,7 @@
             }
         }
     },
-    "portscan.enabled": false,
+    "portscan.enabled": true,
     "portscan.ignore_localhost": false,
     "portscan.logfile":"/var/log/kern.log",
     "portscan.synrate": 5,

--- a/opencanary/config.py
+++ b/opencanary/config.py
@@ -2,6 +2,7 @@ from six import iteritems
 import os, sys, json, copy, socket, itertools, string, subprocess
 from os.path import expanduser
 from pkg_resources import resource_filename
+from pathlib import Path
 
 SAMPLE_SETTINGS = resource_filename(__name__, 'data/settings.json')
 SETTINGS = 'opencanary.conf'
@@ -19,6 +20,9 @@ def expand_vars(var):
         return os.path.expandvars(var)
     return var
 
+def is_docker():
+    cgroup = Path('/proc/self/cgroup')
+    return Path('/.dockerenv').is_file() or cgroup.is_file() and 'docker' in cgroup.read_text()
 
 class Config:
     def __init__(self, configfile=SETTINGS):

--- a/opencanary/modules/portscan.py
+++ b/opencanary/modules/portscan.py
@@ -64,7 +64,7 @@ class SynLogWatcher(FileSystemWatcher):
             if int(data.get('dst_port', -1)) in self.ignore_ports:
                 continue
 
-            
+
             self.logger.log(data)
 
 class CanaryPortscan(CanaryService):
@@ -111,13 +111,6 @@ class CanaryPortscan(CanaryService):
         # We ignore loopback interface traffic as it is taken care of in above rule
         os.system('sudo {0} -t mangle -D PREROUTING -p tcp --syn -j LOG --log-level=warning --log-prefix="canaryfw: " -m limit --limit="{1}/second" ! -i lo'.format(iptables_path, self.synrate))
         os.system('sudo {0} -t mangle -A PREROUTING -p tcp --syn -j LOG --log-level=warning --log-prefix="canaryfw: " -m limit --limit="{1}/second" ! -i lo'.format(iptables_path, self.synrate))
-
-        # os.system('sudo /sbin/iptables -t mangle -D PREROUTING -p tcp {dst} --syn -j LOG --log-level=warning --log-prefix="canaryfw: " -m limit --limit="{synrate}/second"'
-        #             .format(dst=(('--destination '+self.listen_addr) if len(self.listen_addr) else ''),
-        #                 synrate=self.synrate))
-        # os.system('sudo /sbin/iptables -t mangle -A PREROUTING -p tcp {dst} --syn -j LOG --log-level=warning --log-prefix="canaryfw: " -m limit --limit="{synrate}/second"'
-        #             .format(dst=(('--destination '+self.listen_addr) if len(self.listen_addr) else ''),
-        #                 synrate=self.synrate))
 
          # Match the T3 probe of the nmap OS detection based on TCP flags and TCP options string
         os.system('sudo {0} -t mangle -D PREROUTING -p tcp --tcp-flags ALL URG,PSH,SYN,FIN -m u32 --u32 "40=0x03030A01 && 44=0x02040109 && 48=0x080Affff && 52=0xffff0000 && 56=0x00000402" -j LOG --log-level=warning --log-prefix="canarynmap: " -m limit --limit="{1}/second"'.format(iptables_path, self.nmaposrate))


### PR DESCRIPTION
## Proposed changes

We want to tell folks that they cannot use portscan while in a docker container. This change does just that. It automatically disables portscan if in docker and prints out a little statement. Mentioned in #216 (and a few others).

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have added necessary documentation (if appropriate)
- [x] Linked to the relevant github issue or github discussion
