### PR TITLE
Add docker build action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Docker build
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [published]
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set Image tag
+        run: |
+          if [[ "${{ github.ref_name }}" == "master" ]]; then
+              echo "TAG=latest" >> "$GITHUB_ENV"
+          else
+              echo "TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.latest
+          platforms: linux/amd64,linux/arm64
+          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:${{ env.TAG }}
+          cache-to: type=inline
+          tags: ghcr.io/${{ github.repository }}:${{ env.TAG }}


### PR DESCRIPTION
## Proposed changes

Builds a docker image, and uploads it to Github Container Registry.

With every push to master, it updates the `latest` tag, and on every release, it creates a tag corresponding to the release version.

You can see it in action on our fork:
https://github.com/outsideopen/opencanary/pkgs/container/opencanary

There are a lot of Docker images for Opencanary available, but I thought it might be good to have an "official build" as part of the repo.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

We can push the resulting image to Docker Hub instead of Github Container Registry, if that is preferable, but it will require more configuration, whereas support for GHCR is built into Github Actions.
