### PR TITLE
Portscan improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ to github@thinkst.com.
 * Python 3.7 (Recommended Python 3.7+)
 * [Optional] SNMP requires the Python library scapy
 * [Optional] Samba module needs a working installation of samba
+* [Optional] Portscan uses iptables (not nftables) and is only supported on Linux based operating systems
 ## Features
 
 * Mimic an array of network-accessible services for attackers to interact with.

--- a/bin/opencanary.tac
+++ b/bin/opencanary.tac
@@ -4,7 +4,7 @@ import sys
 from twisted.application import service
 from pkg_resources import iter_entry_points
 
-from opencanary.config import config, is_docker
+from opencanary.config import config, is_docker, detectIPTables
 from opencanary.logger import getLogger
 from opencanary.modules.http import CanaryHTTP
 from opencanary.modules.https import CanaryHTTPS
@@ -74,6 +74,8 @@ if sys.platform.startswith("linux"):
     if config.moduleEnabled("portscan") and is_docker():
         # Remove portscan if running in DOCKER (specified in Dockerfile)
         print("Can't use portscan in Docker. Portscan module disabled.")
+    elif config.moduleEnabled("portscan") and not detectIPTables():
+        print("Can't use portscan without iptables. Please install iptables.")
     else:
         from opencanary.modules.portscan import CanaryPortscan
 

--- a/docs/services/windows.rst
+++ b/docs/services/windows.rst
@@ -69,4 +69,4 @@ to use rsyslog, we will edit the `/etc/rsyslog.conf` file. Below are two lines w
 This will redirect any message of facility local7 to your `/var/log/samba-audit.log` file, which will be
 watched by our OpenCanary daemon.
 
-Please note this is all written up in the GitHub README.md
+Please note this is all written up in the GitHub Wiki.

--- a/docs/starting/configuration.rst
+++ b/docs/starting/configuration.rst
@@ -37,13 +37,8 @@ You may also want to fiddle with some of our other services which require a bit 
 
 `smb` - a log watcher for Samba logging files which allows Opencanary to alert on files being opened in a Windows File Share.
 
-For this configuration, you will need to set up your own Windows File Share, and point Opencanary at it using the following configuration,
+For this configuration, you will need to set up your own Windows File Share. Please read the steps over `here <https://github.com/thinkst/opencanary/wiki/Opencanary-and-Samba>`_.
 
-.. code-block:: json
-
-    "smb.auditfile": "/var/log/samba-audit.log",
-
-which is where your Windows File Share will be logging any activity happening on that share.
 
 `portscan` - a log watcher that works with iptables to monitor when your Opencanary is being scanned.
 At this stage, the portscan module supports the detection of Nmap OS, Nmap FIN, Nmap OS, Nmap NULL, and normal port scans.

--- a/docs/starting/configuration.rst
+++ b/docs/starting/configuration.rst
@@ -39,9 +39,9 @@ You may also want to fiddle with some of our other services which require a bit 
 
 For this configuration, you will need to set up your own Windows File Share. Please read the steps over `here <https://github.com/thinkst/opencanary/wiki/Opencanary-and-Samba>`_.
 
-
 `portscan` - a log watcher that works with iptables to monitor when your Opencanary is being scanned.
 At this stage, the portscan module supports the detection of Nmap OS, Nmap FIN, Nmap OS, Nmap NULL, and normal port scans.
+`portscan.iptables_path` is available for you to specify the path to your `iptables` binary.
 
 Logger Configuration
 --------------------

--- a/opencanary/config.py
+++ b/opencanary/config.py
@@ -5,6 +5,7 @@ import json
 import itertools
 import string
 import subprocess
+import shutil
 from os.path import expanduser
 from pkg_resources import resource_filename
 from pathlib import Path
@@ -33,6 +34,13 @@ def is_docker():
         or cgroup.is_file()
         and "docker" in cgroup.read_text()
     )
+
+
+def detectIPTables():
+    if shutil.which("iptables"):
+        return True
+    else:
+        return False
 
 
 class Config:


### PR DESCRIPTION
## Proposed changes

This commit brings about some improvements to the portscan module. 
1. It allows users to specify a path to the `iptables` binary via a config setting: `portscan.iptables_path`
2. It checks if the system running opencanary has `iptables`.
3. if `nftables` is found, we use `iptables-legacy`.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added necessary documentation (if appropriate)
- [x] Linked to the relevant github issue or github discussion (#296)
