### PR TITLE
Add rsa-sha2-512 and rsa-sha2-256, keys

### DIFF
--- a/opencanary/modules/ssh.py
+++ b/opencanary/modules/ssh.py
@@ -421,9 +421,13 @@ class CanarySSH(CanaryService):
         factory.publicKeys = {
             b"ssh-rsa": keys.Key.fromString(data=rsa_pubKeyString),
             b"ssh-dss": keys.Key.fromString(data=dsa_pubKeyString),
+            b"rsa-sha2-512": keys.Key.fromString(data=rsa_pubKeyString),
+            b"rsa-sha2-256": keys.Key.fromString(data=rsa_pubKeyString),
         }
         factory.privateKeys = {
             b"ssh-rsa": keys.Key.fromString(data=rsa_privKeyString),
             b"ssh-dss": keys.Key.fromString(data=dsa_privKeyString),
+            b"rsa-sha2-512": keys.Key.fromString(data=rsa_privKeyString),
+            b"rsa-sha2-256": keys.Key.fromString(data=rsa_privKeyString),
         }
         return internet.TCPServer(self.port, factory, interface=self.listen_addr)


### PR DESCRIPTION
## Proposed changes

There has been issues the open-canary `ssh` server, not being able to complete an `ssh` connection with some clients if they don't offer the "Host Key Algorithms" `ssh-rsa` and `ssh-dss`. (https://github.com/thinkst/opencanary/issues/186)
After some testing we found out that, usually if the "Host Key Algorithms" above are not offered,  a client would then offer these Algorithms, `rsa-sha2-512` `rsa-sha2-256`, instead.
These changes add support for the "Host Key Algorithms" `rsa-sha2-512` `rsa-sha2-256`, to the open-canary `ssh` server.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ x] Lint and unit tests pass locally with my changes (if applicable)
- [ x] I have run pre-commit (`pre-commit` in the repo)
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ x] Linked to the relevant github issue or github discussion
