### PR TITLE
Add listen_addr parameter to modules where it missed

### DIFF
--- a/opencanary/modules/git.py
+++ b/opencanary/modules/git.py
@@ -76,7 +76,8 @@ class CanaryGit(Factory, CanaryService):
     def __init__(self, config=None, logger=None):
         CanaryService.__init__(self, config=config, logger=logger)
         self.port = config.getVal("git.port", default=9418)
+        self.listen_addr = config.getVal("device.listen_addr", default="")
         self.logtype = logger.LOG_GIT_CLONE_REQUEST
 
     def getService(self):
-        return internet.TCPServer(self.port, self)
+        return internet.TCPServer(self.port, self, interface=self.listen_addr)

--- a/opencanary/modules/rdp.py
+++ b/opencanary/modules/rdp.py
@@ -4,6 +4,7 @@ from opencanary.modules import CanaryService
 
 from twisted.internet.protocol import Protocol
 from twisted.internet.protocol import Factory
+from twisted.application import internet
 
 
 class RemoteDesktopProtocol(Protocol):
@@ -45,7 +46,11 @@ class CanaryRDP(Factory, CanaryService):
     def __init__(self, config=None, logger=None):
         CanaryService.__init__(self, config, logger)
         self.port = config.getVal("rdp.port", 3389)
+        self.listen_addr = config.getVal("device.listen_addr", default="")
         self.logtype = logger.LOG_RDP
+
+    def getService(self):
+        return internet.TCPServer(self.port, self, interface=self.listen_addr)
 
 
 CanaryServiceFactory = CanaryRDP

--- a/opencanary/modules/redis.py
+++ b/opencanary/modules/redis.py
@@ -439,9 +439,10 @@ class CanaryRedis(Factory, CanaryService):
 
     def __init__(self, config=None, logger=None):
         CanaryService.__init__(self, config=config, logger=logger)
+        self.listen_addr = config.getVal("device.listen_addr", default="")
         self.port = config.getVal("redis.port", default=6379)
         self.max_arg_length = config.getVal("redis.max_arg_length", default=30)
         self.logtype = logger.LOG_REDIS_COMMAND
 
     def getService(self):
-        return internet.TCPServer(self.port, self)
+        return internet.TCPServer(self.port, self,  interface=self.listen_addr)

--- a/opencanary/modules/vnc.py
+++ b/opencanary/modules/vnc.py
@@ -2,6 +2,7 @@ from opencanary.modules import CanaryService
 
 from twisted.internet.protocol import Protocol
 from twisted.internet.protocol import Factory
+from twisted.application import internet
 
 from opencanary.modules.des import des
 
@@ -172,7 +173,11 @@ class CanaryVNC(Factory, CanaryService):
     def __init__(self, config=None, logger=None):
         CanaryService.__init__(self, config, logger)
         self.port = config.getVal("vnc.port", 5900)
+        self.listen_addr = config.getVal("device.listen_addr", default="")
         self.logtype = logger.LOG_VNC
+
+    def getService(self):
+        return internet.TCPServer(self.port, self, interface=self.listen_addr)
 
 
 CanaryServiceFactory = CanaryVNC


### PR DESCRIPTION
## Proposed changes

The modules for imitation rdp, redis, git and vnc protocols don't use "device.listen_addr" parameter from config file. So there is no problem if you have only IPv4 network interfaces on your host where Opencanary is running as it runs on all ipv4 addresses by default. But if you have only IPv6 network this modules cannot be used.

I simply added `self.listen_addr` just as it is in other modules