### PR TITLE
Fix OpenCanary docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Please head over to our forked repository for an Ansible OpenCanary role over [h
 ## Documentation
 
 * The [Wiki](https://github.com/thinkst/opencanary/wiki) contains our FAQ.
-* Additional documentation is available on our [main site](https://opencanary.org).
+* Additional documentation is available on our [main site](http://opencanary.org).
 
 ## Project Participation
 


### PR DESCRIPTION
## Proposed changes

Docs link (opencanary.org) was pointing to HTTPS site, but we only serve on HTTP (so the page doesn't load after clicking on the link). Updated the link to point to HTTP, since we immediately redirect to readthedocs.io which is served over HTTPS anyway.

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update