### PR TITLE
Re-work drop root privileges

### DIFF
--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -47,6 +47,6 @@ jobs:
       - name: Copy config file
         run: cp opencanary/test/opencanary.conf .
       - name: Start OpenCanary
-        run: opencanaryd --start --allow-run-as-root
+        run: opencanaryd --start
       - name: Run Pytest
         run: pytest -s

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -26,4 +26,4 @@ COPY opencanary ./opencanary
 ENTRYPOINT [ "opencanaryd" ]
 
 # Set the default arguments to be used for the entrypoint
-CMD [ "--dev" ]
+CMD [ "--dev", "--uid=nobody", "--gid=nogroup" ]

--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -15,4 +15,4 @@ RUN pip install scapy pcapy-ng
 ENTRYPOINT [ "opencanaryd" ]
 
 # Set the default arguments to be used for the entrypoint
-CMD [ "--dev" ]
+CMD [ "--dev", "--uid=nobody", "--gid=nogroup" ]

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To create an initial configuration, run as `root` (you may be prompted for a `su
 $ opencanaryd --copyconfig
 [*] A sample config file is ready /etc/opencanaryd/opencanary.conf
 
-[*] Edit your configuration, then launch with "opencanaryd --start"
+[*] Edit your configuration, then launch with "opencanaryd --start --uid=nobody --gid=nogroup"
 ```
 
 This creates the path and file `/etc/opencanaryd/opencanary.conf`. You must now edit the config file to determine which services and logging options you want to enable.
@@ -187,16 +187,21 @@ Start OpenCanary by running:
 
 ```
 $ . env/bin/activate
-$ opencanaryd --start
+$ opencanaryd --start --uid=nobody --gid=nogroup
 ```
+
+With the `uid` and `gid` flags, OpenCanary drops root privileges after binding to its ports. This can be changed to other low-privileged user/group or omitted to keep running with root privileges.
 
 ### With pkgx
 
 Start OpenCanary by running:
 
 ```
-$ sudo -E pkgx opencanaryd --start
+$ sudo -E pkgx opencanaryd --start --uid=nobody --gid=nogroup
 ```
+
+With the `uid` and `gid` flags, OpenCanary drops root privileges after binding to its ports. This can be changed to other low-privileged user/group or omitted to keep running with root privileges.
+
 
 ### With docker-compose
 

--- a/README.md
+++ b/README.md
@@ -157,43 +157,6 @@ $ opencanaryd --copyconfig
 
 This creates the path and file `/etc/opencanaryd/opencanary.conf`. You must now edit the config file to determine which services and logging options you want to enable.
 
-### Setting privileges
-
-OpenCanary requires root to bind to privileged ports, after which it attempts to drop to a less privileged
-user and group ID (default is `opencanary/nogroup`).
-
-If this behaviour is not desired, one can use the `--allow-run-as-root` flag, e.g.,
-
-```
-$ opencanaryd --start --allow-run-as-root
-```
-
-Creating the `opencanary` user and giving necessary privileges, run `./bin/opencanaryd --createuser`. To drop to a
-custom user or group, simply use the `--uid` and `--gid` options respectively:
-
-```
-$ opencanaryd --start --uid username --gid groupname
-```
-
-By default, the `uid:gid` is `opencanary:nogroup`.
-
-#### Installing and running OpenCanary on an isolated `opencanary` user
-
-The recommended installation process would be as follows:
-
-1. Obtain an installation candidate `opencanary-<version>.tar.gz` e.g., via [Installation via Git](#installation-via-git)
-2. Make sure all users can read this file, e.g, `sudo chmod 744 /path/to/opencanary-<version>.tar.gz`.
-3. Run the following commands as `opencanary`, i.e., `sudo su - opencanary`:
-   1. Create virtual environment `pip3 install virtualenv && python3 -m virtualenv .venv`.
-   2. Install Opencanary distribution `pip3 install /path/to/opencanary-<version>.tar.gz`.
-4. Activate the `opencanary` virtual environment from a user that is able to use `sudo`
-   (necessary to bind to privileged ports), e.g., `source /home/opencanary/.venv/bin/activate`
-5. Navigate back to `opencanary`'s home, e.g., `cd /home/opencanary` or `cd /Users/opencanary`. If this step is not done,
-   there may be issues when the `opencanary` user tries to navigate from this (possibly more privileged) directory.
-6. Run the `opencanaryd` binary as usual , e.g., `opencanaryd --start`.
-
-This should drop to the `opencanary` user once bound to privileged ports, and safely operate in an isolated environment.
-
 ### Enabling protocol modules and alerting
 
 Configuration is performed via the JSON config file. Edit the file, and when happy save and exit.
@@ -224,7 +187,7 @@ Start OpenCanary by running:
 
 ```
 $ . env/bin/activate
-$ opencanaryd --start --allow-run-as-root
+$ opencanaryd --start
 ```
 
 ### With pkgx

--- a/bin/opencanaryd
+++ b/bin/opencanaryd
@@ -3,26 +3,18 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PIDFILE="${DIR}/opencanaryd.pid"
 
 cmd=$1
-allow_run_as_root=false
-uid_=""
-gid_=""
 
 function usage() {
     echo -e "\n  OpenCanary\n"
-    echo -e "\topencanaryd [ --start | --dev | --stop | --restart | --copyconfig | --usermodule | --createuser | --version | --help ] [--allow-run-as-root | --uid=opencanary --gid=nogroup]\n\n"
+    echo -e "\topencanaryd [ --start | --dev | --stop | --restart | --copyconfig | --usermodule | --version | --help ]\n\n"
     echo -e "\t\t--start\tStarts the opencanaryd process"
     echo -e "\t\t--dev\tRun the opencanaryd process in the foreground"
     echo -e "\t\t--stop\tStops the opencanaryd process"
     echo -e "\t\t--usermodule\tRun opencanaryd in foreground with only usermodules enabled"
     echo -e "\t\t--copyconfig\tCreates a default config file at /etc/opencanaryd/opencanary.conf"
-    echo -e "\t\t--createuser\tCreate the 'opencanary' user and respective home directory for isolation purposes"
     echo -e "\t\t--version\tDisplays the current opencanary version."
     echo -e "\t\t--"
     echo -e "\t\t--help\tThis help\n"
-    echo -e "\toptions"
-    echo -e "\t\t--allow-run-as-root\tDo not drop privileges of the opencanary once process starts"
-    echo -e "\t\t--uid\tSpecify a user ID to drop privileges to"
-    echo -e "\t\t--gid\tSpecify a group ID to drop privileges to"
 
 }
 
@@ -36,47 +28,10 @@ function sudo() {
   fi
 }
 
-# Set options if supplied
-for arg in "$@"; do
-    case $arg in
-        --uid=*)
-            uid_="${arg#*=}"
-            ;;
-        --gid=*)
-            gid_="${arg#*=}"
-            ;;
-        --allow-run-as-root)
-            allow_run_as_root=true
-            ;;
-    esac
-done
-
-# Build twistd command suffix based on options
-twist_permissions_opts=""
-
-if [ "$allow_run_as_root" = false ]; then
-    if [ -z "$uid_" ]; then
-      uid_="opencanary"
-    fi
-    twist_permissions_opts="${twist_permissions_opts} --uid ${uid_}"
-
-    if [ -z "$gid_" ]; then
-      gid_="nogroup"
-    fi
-    twist_permissions_opts="${twist_permissions_opts} --gid ${gid_}"
-fi
-
-# Only run the following if we expect to run a sudoers command later
-if [[ "${cmd}" != "--help" && "${cmd}" != "--version" && "${cmd}" != "--createuser" && $(id $uid_ &>/dev/null; echo $?) -eq 0 ]]; then
-  # Ensure logging file and HTTP static content perms are correct
-  sudo touch /var/tmp/opencanary.log && sudo chmod 755 /var/tmp/opencanary.log
-  sudo mkdir -p /etc/opencanaryd && sudo chown -R ${uid_}:${gid_} /etc/opencanaryd
-fi
-
 if [ "${cmd}" == "--start" ]; then
-    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd $twist_permissions_opts
+    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
 elif [ "${cmd}" == "--dev" ]; then
-    sudo -E "${DIR}/twistd" -noy "${DIR}/opencanary.tac" $twist_permissions_opts
+    sudo -E "${DIR}/twistd" -noy "${DIR}/opencanary.tac"
 elif [ "${cmd}" == "--usermodule" ]; then
   usermodconf=$(python -c "from pkg_resources import resource_filename; print(resource_filename('opencanary', 'data/settings-usermodule.json'))")
 
@@ -93,7 +48,7 @@ elif [ "${cmd}" == "--usermodule" ]; then
 elif [ "${cmd}" == "--restart" ]; then
     pid=`sudo -E cat "${PIDFILE}"`
     sudo -E kill "$pid"
-    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd $twist_permissions_opts
+    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
 elif [ "${cmd}" == "--stop" ]; then
     pid=`sudo -E cat "${PIDFILE}"`
     sudo -E kill "$pid"
@@ -105,29 +60,8 @@ elif [ "${cmd}" == "--copyconfig" ]; then
     defaultconf=$(python3 -c "from pkg_resources import resource_filename; print(resource_filename('opencanary', 'data/settings.json'))")
     sudo -E mkdir -p /etc/opencanaryd
     sudo -E cp "${defaultconf}" /etc/opencanaryd/opencanary.conf
-    sudo chown ${uid_}:${gid_} /etc/opencanaryd && sudo chmod -R 600 /etc/opencanaryd
     echo -e "[*] A sample config file is ready /etc/opencanaryd/opencanary.conf\n"
     echo    "[*] Edit your configuration, then launch with \"opencanaryd --start\""
-elif [ "${cmd}" == "--createuser" ]; then
-  if id opencanary &>/dev/null; then
-    echo "User 'opencanary' already exists."
-    exit 1
-  fi
-  if [[ "$(uname)" == "Darwin" ]]; then # macos
-    sudo dscl . -create /Users/opencanary
-    sudo dscl . -create /Users/opencanary UserShell /bin/bash
-    sudo dscl . -create /Users/opencanary RealName "OpenCanary"
-    next_uid=$(($(dscl . -list /Users UniqueID | awk '$2 >= 1000 {print $2}' | sort -n | tail -n 1) + 2))
-    sudo dscl . -create /Users/opencanary UniqueID "${next_uid}"
-    sudo dscl . -create /Users/opencanary PrimaryGroupID $(dscl . -read /Groups/nogroup | awk '/PrimaryGroupID: / {print $2}')
-    sudo dscl . -create /Users/opencanary NFSHomeDirectory /Users/opencanary
-    sudo mkdir -p /Users/opencanary
-    sudo chown opencanary:nogroup /Users/opencanary
-    sudo chmod 755 /Users/opencanary
-  else # other, e.g., Linux
-    sudo useradd -m -s /bin/bash -c "OpenCanary" --gid nogroup opencanary
-    sudo chown -R opencanary:nogroup /home/opencanary
-  fi
 elif [ "${cmd}" == "--version" ]; then
     python -c "from opencanary import __version__; print(__version__);"
 else

--- a/bin/opencanaryd
+++ b/bin/opencanaryd
@@ -6,7 +6,7 @@ cmd=$1
 
 function usage() {
     echo -e "\n  OpenCanary\n"
-    echo -e "\topencanaryd [ --start | --dev | --stop | --restart | --copyconfig | --usermodule | --version | --help ]\n\n"
+    echo -e "\topencanaryd [ --start | --dev | --stop | --restart | --copyconfig | --usermodule | --version | --help ] [--uid=nobody] [--gid=nogroup]\n\n"
     echo -e "\t\t--start\tStarts the opencanaryd process"
     echo -e "\t\t--dev\tRun the opencanaryd process in the foreground"
     echo -e "\t\t--stop\tStops the opencanaryd process"
@@ -15,8 +15,27 @@ function usage() {
     echo -e "\t\t--version\tDisplays the current opencanary version."
     echo -e "\t\t--"
     echo -e "\t\t--help\tThis help\n"
-
+    echo -e "\toptions"
+    echo -e "\t\t--allow-run-as-root\tDo not drop privileges of the opencanary once process starts"
+    echo -e "\t\t--uid\tSpecify a user or uid to drop privileges to"
+    echo -e "\t\t--gid\tSpecify a group of gid to drop privileges to"
 }
+
+# Parse options
+for arg in "$@"; do
+   case $arg in
+        --uid=*)
+            readonly TWISTD_UID_FLAG=" --uid=${arg#*=}"
+            ;;
+        --gid=*)
+            readonly TWISTD_GID_FLAG=" --gid=${arg#*=}"
+            ;;
+    esac
+done
+
+if [[ -z $TWISTD_UID_FLAG || -z $TWISTD_GID_FLAG ]]; then
+    echo "WARNING: OpenCanary will not drop root user or group privileges after launching. Set both --uid=nobody and --gid=nogroup (another other low privilege user/group) to silence this warning."
+fi
 
 # Use sudo when not running as root
 function sudo() {
@@ -29,9 +48,9 @@ function sudo() {
 }
 
 if [ "${cmd}" == "--start" ]; then
-    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
+    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd ${TWISTD_UID_FLAG:-} ${TWISTD_GID_FLAG:-}
 elif [ "${cmd}" == "--dev" ]; then
-    sudo -E "${DIR}/twistd" -noy "${DIR}/opencanary.tac"
+    sudo -E "${DIR}/twistd" -noy "${DIR}/opencanary.tac" ${TWISTD_UID_FLAG:-} ${TWISTD_GID_FLAG:-}
 elif [ "${cmd}" == "--usermodule" ]; then
   usermodconf=$(python -c "from pkg_resources import resource_filename; print(resource_filename('opencanary', 'data/settings-usermodule.json'))")
 
@@ -48,7 +67,7 @@ elif [ "${cmd}" == "--usermodule" ]; then
 elif [ "${cmd}" == "--restart" ]; then
     pid=`sudo -E cat "${PIDFILE}"`
     sudo -E kill "$pid"
-    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd
+    sudo -E "${DIR}/twistd" -y "${DIR}/opencanary.tac" --pidfile "${PIDFILE}" --syslog --prefix=opencanaryd ${TWISTD_UID_FLAG:-} ${TWISTD_GID_FLAG:-}
 elif [ "${cmd}" == "--stop" ]; then
     pid=`sudo -E cat "${PIDFILE}"`
     sudo -E kill "$pid"


### PR DESCRIPTION
## Proposed changes

The original change broke backward compatibility and the default OpenCanary invocation in the container. This change reverts the original behaviour when no uid/gid flags are specified, while still nudging the default and container invocations to drop root privileges.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes  #377 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...