### PR TITLE
Simplify search for iptables executable

### DIFF
--- a/bin/opencanary.tac
+++ b/bin/opencanary.tac
@@ -4,7 +4,7 @@ import sys
 from twisted.application import service
 from pkg_resources import iter_entry_points
 
-from opencanary.config import config, is_docker, detectIPTables
+from opencanary.config import config, is_docker
 from opencanary.logger import getLogger
 from opencanary.modules.http import CanaryHTTP
 from opencanary.modules.https import CanaryHTTPS
@@ -84,8 +84,6 @@ if sys.platform.startswith("linux"):
     if config.moduleEnabled("portscan") and is_docker():
         # Remove portscan if running in DOCKER (specified in Dockerfile)
         print("Can't use portscan in Docker. Portscan module disabled.")
-    elif config.moduleEnabled("portscan") and not detectIPTables():
-        print("Can't use portscan without iptables. Please install iptables.")
     else:
         from opencanary.modules.portscan import CanaryPortscan
 

--- a/docs/starting/configuration.rst
+++ b/docs/starting/configuration.rst
@@ -41,7 +41,6 @@ For this configuration, you will need to set up your own Windows File Share. Ple
 
 `portscan` - a log watcher that works with iptables to monitor when your Opencanary is being scanned.
 At this stage, the portscan module supports the detection of Nmap OS, Nmap FIN, Nmap OS, Nmap NULL, and normal port scans.
-`portscan.iptables_path` is available for you to specify the path to your `iptables` binary.
 
 Logger Configuration
 --------------------

--- a/opencanary/__init__.py
+++ b/opencanary/__init__.py
@@ -6,6 +6,7 @@ __version__ = "0.9.5"
 
 STDPATH = os.pathsep.join(["/usr/bin", "/bin", "/usr/sbin", "/sbin"])
 
+
 def safe_exec(binary_name: str, args: list) -> bytes:
     """
     Executes the given binary with the given arguments as a subprocess. What makes this safe is that the binary name

--- a/opencanary/__init__.py
+++ b/opencanary/__init__.py
@@ -1,21 +1,5 @@
 import os
-import shutil
-import subprocess
 
 __version__ = "0.9.5"
 
 STDPATH = os.pathsep.join(["/usr/bin", "/bin", "/usr/sbin", "/sbin"])
-
-
-def safe_exec(binary_name: str, args: list) -> bytes:
-    """
-    Executes the given binary with the given arguments as a subprocess. What makes this safe is that the binary name
-    is not executed as an alias, and only binaries that live in trusted system locations are executed. This means that
-    only system-wide binaries are executable.
-    """
-    exec_path = shutil.which(binary_name, path=STDPATH)
-    if exec_path is None:
-        raise Exception(f"Could not find executable ${binary_name} in ${STDPATH}")
-
-    args.insert(0, exec_path)
-    return subprocess.check_output(args)

--- a/opencanary/config.py
+++ b/opencanary/config.py
@@ -8,7 +8,6 @@ import re
 from os.path import expanduser
 from pkg_resources import resource_filename
 from pathlib import Path
-from . import safe_exec
 
 SAMPLE_SETTINGS = resource_filename(__name__, "data/settings.json")
 SETTINGS = "opencanary.conf"
@@ -34,13 +33,6 @@ def is_docker():
         or cgroup.is_file()
         and "docker" in cgroup.read_text()
     )
-
-
-def detectIPTables():
-    if shutil.which("iptables"):
-        return True
-    else:
-        return False
 
 
 SERVICE_REGEXES = {
@@ -77,7 +69,6 @@ class Config:
                 print("[-] Failed to open %s for reading (%s)" % (fname, e))
             except ValueError as e:
                 print("[-] Failed to decode json from %s (%s)" % (fname, e))
-                safe_exec("cp", ["-r", fname, "/var/tmp/config-err-$(date +%%s)"])
             except Exception as e:
                 print("[-] An error occurred loading %s (%s)" % (fname, e))
         if self.__config is None:

--- a/opencanary/config.py
+++ b/opencanary/config.py
@@ -3,7 +3,6 @@ import sys
 import json
 import itertools
 import string
-import shutil
 import re
 from os.path import expanduser
 from pkg_resources import resource_filename

--- a/opencanary/modules/portscan.py
+++ b/opencanary/modules/portscan.py
@@ -67,6 +67,7 @@ class SynLogWatcher(FileSystemWatcher):
 
             self.logger.log(data)
 
+
 class CanaryPortscan(CanaryService):
     NAME = "portscan"
 
@@ -103,13 +104,20 @@ class CanaryPortscan(CanaryService):
         pass
 
     def set_iptables_rules(self):
-        iptables_path = shutil.which("iptables-legacy", STDPATH) or shutil.which("iptables", STDPATH)
+        iptables_path = shutil.which("iptables-legacy", path=STDPATH)
 
         if not iptables_path:
-            raise Exception("Portscan module failed to start as iptables cannot be found. Please install iptables.")
+            iptables_path = shutil.which("iptables", path=STDPATH)
+
+        if not iptables_path:
+            err = "Portscan module failed to start as iptables cannot be found. Please install iptables."
+            print(err)
+            raise Exception(err)
 
         if b"nf_tables" in subprocess.check_output([iptables_path, "--version"]):
-            raise Exception("Portscan module failed to start as iptables-legacy cannot be found. Please install iptables-legacy")
+            err = "Portscan module failed to start as iptables-legacy cannot be found. Please install iptables-legacy"
+            print(err)
+            raise Exception(err)
 
         os.system(
             'sudo {0} -t mangle -D PREROUTING -p tcp -i lo -j LOG --log-level=warning --log-prefix="canaryfw: " -m limit --limit="{1}/hour"'.format(


### PR DESCRIPTION
## Proposed changes

A recent change aimed to limit the PATH directories in which to search for `iptables` executables. This led to inconsistent search for `iptables` binaries depending on which calling code was searching for and one incorrect search which broke `iptables`. This change simplifies the search to a single check for `iptables` in one place, and restricts it to the standard unix PATHs.

This also removes the ability to specify the `iptables` binary in the config file as it may be possible, if an unprivileged user has the ability to write to a config file in use and escalate permissions when OpenCanary daemon later runs as root.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments