### PR TITLE
Added Samba docker container to allow for easier deployment of smb service

### DIFF
--- a/Dockerfile.smb
+++ b/Dockerfile.smb
@@ -1,0 +1,23 @@
+FROM debian:stable
+
+# Download cache lists and install minimal versions
+RUN apt-get update && apt-get -yq install --no-install-recommends \
+	# Required linux dependencies
+	sudo vim samba samba-vfs-modules smbclient rsyslog && \
+	# Remove cache lists and clean up anything not needed to minimize image size
+	apt-get autoremove -yq && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /samba
+COPY data/smb /samba/
+RUN touch /var/log/samba/audit.log
+RUN echo "local7.*        /var/log/samba/audit.log" >> /etc/rsyslog.conf
+
+# Create and set the working directory
+WORKDIR /srv
+
+# Copy only the files needed to install dependencies
+COPY run-smb.sh .
+
+# Set the default application we are running
+ENTRYPOINT [ "/srv/run-smb.sh" ]
+

--- a/data/.opencanary.conf
+++ b/data/.opencanary.conf
@@ -77,7 +77,7 @@
     "portscan.nmaposrate": 5,
     "portscan.lorate": 3,
     "portscan.ignore_ports": [ ],
-    "smb.auditfile": "/var/log/samba-audit.log",
+    "smb.auditfile": "/var/log/samba/audit.log",
     "smb.enabled": false,
     "mysql.enabled": false,
     "mysql.port": 3306,

--- a/data/smb.conf
+++ b/data/smb.conf
@@ -1,0 +1,28 @@
+[global]
+   workgroup = WORKGROUP
+   server string = NBDocs
+   netbios name = SRV01
+   dns proxy = no
+   log file = /var/log/samba/log.all
+   log level = 0
+   max log size = 100
+   panic action = /usr/share/samba/panic-action %d
+   server role = standalone
+   passdb backend = tdbsam
+   obey pam restrictions = yes
+   unix password sync = no
+   map to guest = bad user
+   usershare allow guests = yes
+   load printers = no
+   vfs object = full_audit
+   full_audit:prefix = %U|%I|%i|%m|%S|%L|%R|%a|%T|%D
+   full_audit:success = flistxattr
+   full_audit:failure = none
+   full_audit:facility = local7
+   full_audit:priority = notice
+[myshare]
+   comment = All the stuff!
+   path = /samba
+   guest ok = yes
+   read only = yes
+   browseable = yes

--- a/data/smb/README.txt
+++ b/data/smb/README.txt
@@ -1,0 +1,1 @@
+All files in this directory are copied and shared via Samba. Keep in mind that this share will allow guest access.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: "3.4"
 
 x-common: &common
   restart: unless-stopped
   volumes:
     - ./data/.opencanary.conf:/root/.opencanary.conf
     # uncomment below if running Samba
-    # - /var/log/samba-audit.log:/var/log/samba-audit.log
+    # - audit-log:/var/log/samba
   image: "opencanary"
   network_mode: "host"
   ports:
@@ -44,7 +43,7 @@ x-common: &common
     # - "9418:9418"
 
 services:
-  latest: # docker-compose up --build -d latest
+  latest: # docker compose up --build -d latest
     <<: *common
     container_name: opencanary_latest
     image: thinkst/opencanary
@@ -52,9 +51,29 @@ services:
       context: .
       dockerfile: Dockerfile.latest
 
-  stable: # docker-compose up --build -d stable
+  # Uncomment if smb is to be enabled
+  # samba: # docker compose up --build -d samba
+  #   <<: *common
+  #   container_name: opencanary_samba
+  #   image: thinkst/opencanary_samba
+  #   restart: unless-stopped
+  #   volumes:
+  #     - audit-log:/var/log/samba/
+  #     - ./data/smb.conf:/etc/samba/smb.conf
+  #   network_mode: host
+  #   ports:
+  #     # SMB
+  #     - "445:445"
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.smb
+
+  stable: # docker compose up --build -d stable
     <<: *common
     container_name: opencanary_stable
     build:
       context: .
       dockerfile: Dockerfile.stable
+
+volumes:
+  audit-log:

--- a/run-smb.sh
+++ b/run-smb.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rsyslogd &
+smbd &
+sleep infinity


### PR DESCRIPTION
## Proposed changes

This PR adds a new Dockerfile for a container that runs Samba (and rsyslog) that shares a volume with the main opencanary container to share the `/var/log/samba/audit.log`. This allows for the opencanary container to alert/log on SMB accesses.

Things to note:
- This copies the contents of `data/smb` into the container's share (called `myshare` by default) at build time
- Samba uses the `data/smb.conf` as its configuration, allowing for the creation of other shares, or changing the permissions on the existing `myshare`
- To run this, you need to add the `samba` container name into the docker compose command, e.g.: `docker compose up -d samba latest`
- I also updated the comments to reflect the change from `docker-compose` to `docker compose`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
