### PR TITLE
Fix docker build so it falls back to a safe long description

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,5 @@ exclude Dockerfile.latest
 exclude Dockerfile.*
 exclude docker-compose.yml
 exclude .gitignore
+
+include README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,3 @@ exclude Dockerfile.latest
 exclude Dockerfile.*
 exclude docker-compose.yml
 exclude .gitignore
-
-include README.md

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,18 @@ def get_version(rel_path):
         raise RuntimeError("Unable to find version string.")
 
 
+def get_long_description():
+    """
+    Safely read README.md for long_description.
+    """
+    here = os.path.abspath(os.path.dirname(__file__))
+    readme_path = os.path.join(here, "README.md")
+    if not os.path.isfile(readme_path):
+        return "A low interaction honeypot intended to be run on internal networks."
+    with open(readme_path, encoding="utf-8") as f:
+        return f.read()
+
+
 requirements = [
     "Twisted==24.11.0",
     "pyasn1==0.4.5",
@@ -54,7 +66,7 @@ setup(
     author="Thinkst Applied Research",
     author_email="info@thinkst.com",
     description="OpenCanary daemon",
-    long_description=read("README.md"),
+    long_description=get_long_description(),
     long_description_content_type="text/markdown",
     install_requires=requirements,
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ def get_long_description():
     here = os.path.abspath(os.path.dirname(__file__))
     readme_path = os.path.join(here, "README.md")
     if not os.path.isfile(readme_path):
-        exit(1) # Temp tests
         return "A low interaction honeypot intended to be run on internal networks."
     with open(readme_path, encoding="utf-8") as f:
         return f.read()

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,6 @@ requirements = [
     "service-identity==21.1.0",
 ]
 
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
-
 setup(
     name="opencanary",
     version=get_version("opencanary/__init__.py"),
@@ -57,7 +54,7 @@ setup(
     author="Thinkst Applied Research",
     author_email="info@thinkst.com",
     description="OpenCanary daemon",
-    long_description=long_description,
+    long_description=read("README.md"),
     long_description_content_type="text/markdown",
     install_requires=requirements,
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ def get_long_description():
     here = os.path.abspath(os.path.dirname(__file__))
     readme_path = os.path.join(here, "README.md")
     if not os.path.isfile(readme_path):
+        exit(1) # Temp tests
         return "A low interaction honeypot intended to be run on internal networks."
     with open(readme_path, encoding="utf-8") as f:
         return f.read()


### PR DESCRIPTION
## Proposed changes

After updating setup.py to dynamically ready the long description from the readme it introduced a corner case where in some environments the file is not present and setup.py won't run.

This addresses that until we migrate the project to pyproject.toml

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
