### PR TITLE
Change base image to python:3.10-bookworm

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,9 +1,9 @@
-FROM python:3.10-buster
+FROM python:3.10-bookworm
 
 # Download cache lists and install minimal versions
 RUN apt-get update && apt-get -yq install --no-install-recommends \
 	# Required linux dependencies
-	sudo vim build-essential libssl-dev libffi-dev python-dev libpcap-dev && \
+	sudo vim build-essential libssl-dev libffi-dev libpcap-dev && \
 	# Remove cache lists and clean up anything not needed to minimize image size
 	apt-get autoremove -yq && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Updated base image from python:3.10-buster to python:3.10-bookworm and removed python-dev from installation.

## Proposed changes

This update addresses critical compatibility issues caused by Debian Buster reaching end-of-life on June 30, 2024, which resulted in package repositories being removed from the official Debian mirrors.

**Changes made:**
- Upgrade Docker base image from `python:3.10-buster` to `python:3.10-bookworm`
- Remove obsolete `python-dev` package from apt-get install (no longer available in Bookworm; replaced by `python-dev-is-python3` for Python 2.x only, which is unnecessary since development headers are already included in the official Python base image)

**Benefits:**
- Resolves build failures due to "404 Not Found" errors on unavailable Buster repositories
- Ensures continued security updates and package availability (Bookworm is supported until 2026+)
- Maintains Python 3.10 runtime for backward compatibility with existing OpenCanary installations
- Simplifies dependency management by removing deprecated packages

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

The Bookworm base image has been tested and confirmed to successfully build all Docker layers, including the installation of `scapy` and `pcapy-ng` dependencies. No functional changes to OpenCanary are expected, as this is purely an infrastructure update to maintain compatibility with current Debian repositories.
