### PR TITLE
fix tests failing due to old environments

### DIFF
--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -20,7 +20,7 @@ jobs:
   opencanary_tests:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15"]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: "Check out repository code"
-        uses: "actions/checkout@v3"
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Python "${{ matrix.python-version }}"
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
       - name: Install setuptools

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: ["ubuntu-22.04", "ubuntu-24.04", "macos-13", "macos-14", "macos-15"]
+        os: ["ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/opencanary_tests.yml
+++ b/.github/workflows/opencanary_tests.yml
@@ -20,7 +20,7 @@ jobs:
   opencanary_tests:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: ["ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15"]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Proposed changes

Fixes tests failing due to old environments, specifically the `macos-13` runner which has now been retired in github workflows. Python 3.8 and 3.9 are now end of life and may also be removed from the test suite to preserve completion time. Python 3.14 may also now be added to the suite.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

These changes are based on updates made to my fork, which I believe would enhance the original repository. ❤️