### PR TITLE
Fix #418: Ensure PID file cleanup in Docker

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -23,7 +23,7 @@ RUN pip install scapy pcapy-ng
 COPY opencanary ./opencanary
 
 # Set the default application we are running
-ENTRYPOINT [ "opencanaryd" ]
+ENTRYPOINT ["/bin/bash", "-c", "rm -f /usr/local/bin/opencanaryd.pid && exec opencanaryd \"$@\"", "--"]
 
 # Set the default arguments to be used for the entrypoint
 CMD [ "--dev", "--uid=nobody", "--gid=nogroup" ]


### PR DESCRIPTION
In Docker environments, a stale opencanaryd.pid often prevents the container from restarting. This happens because the process drops privileges to nobody, making it unable to remove a PID file owned by root from a previous session.

This PR updates the Dockerfile ENTRYPOINT to clean up the PID file before launch, ensuring a fresh start.