### PR TITLE
Migrate to pytest: mongodb

### DIFF
--- a/opencanary/test/helpers.py
+++ b/opencanary/test/helpers.py
@@ -1,0 +1,26 @@
+import json
+import time
+
+
+LOG_PATH = "/var/tmp/opencanary.log"
+
+
+def get_log_count():
+    with open(LOG_PATH, "r") as file:
+        return len(file.readlines())
+
+
+def get_logs_after(start_line):
+    with open(LOG_PATH, "r") as file:
+        lines = file.readlines()[start_line:]
+    return [json.loads(line) for line in lines]
+
+
+def get_matching_log(start_line, predicate):
+    for _ in range(10):
+        for log in reversed(get_logs_after(start_line)):
+            if predicate(log):
+                return log
+        time.sleep(0.1)
+
+    return None

--- a/opencanary/test/helpers.py
+++ b/opencanary/test/helpers.py
@@ -1,7 +1,6 @@
 import json
 import time
 
-
 LOG_PATH = "/var/tmp/opencanary.log"
 
 

--- a/opencanary/test/helpers.py
+++ b/opencanary/test/helpers.py
@@ -12,7 +12,17 @@ def get_log_count():
 def get_logs_after(start_line):
     with open(LOG_PATH, "r") as file:
         lines = file.readlines()[start_line:]
-    return [json.loads(line) for line in lines]
+
+    parsed_logs = []
+    for line in lines:
+        try:
+            parsed_logs.append(json.loads(line))
+        except json.JSONDecodeError:
+            # The log file may be read while a line is still being written.
+            # Ignore incomplete/malformed lines and continue scanning.
+            continue
+
+    return parsed_logs
 
 
 def get_matching_log(start_line, predicate):

--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -26,19 +26,6 @@ import requests
 import paramiko
 import pymysql
 import git
-from pymongo import MongoClient
-from pymongo.errors import OperationFailure
-
-MONGODB_PORT = 27017
-MONGODB_VERSION = "4.4.6"
-MONGODB_AUTH_FAILED_CODE = 18
-MONGODB_UNAUTHORIZED_CODE = 13
-MONGODB_CLIENT_OPTIONS = {
-    "serverSelectionTimeoutMS": 2000,
-    "connectTimeoutMS": 2000,
-    "socketTimeoutMS": 2000,
-    "directConnection": True,
-}
 
 
 def get_last_log():
@@ -58,37 +45,6 @@ def get_last_n_logs(n):
     last_n_lines = lines[-n:]
     deserialized_data = [json.loads(line) for line in last_n_lines]
     return deserialized_data
-
-
-def get_log_count():
-    with open("/var/tmp/opencanary.log", "r") as file:
-        return len(file.readlines())
-
-
-def get_mongodb_log(action, start_line, logdata=None):
-    logdata = logdata or {}
-    for _ in range(10):
-        for log in reversed(get_logs_after(start_line)):
-            if log["dst_port"] != MONGODB_PORT:
-                continue
-            if log["logdata"].get("action") != action:
-                continue
-            if not all(log["logdata"].get(k) == v for k, v in logdata.items()):
-                continue
-            return log
-        time.sleep(0.1)
-
-    return None
-
-
-def get_logs_after(start_line):
-    with open("/var/tmp/opencanary.log", "r") as file:
-        lines = file.readlines()[start_line:]
-    return [json.loads(line) for line in lines]
-
-
-def get_mongodb_client(uri="mongodb://localhost:27017"):
-    return MongoClient(uri, **MONGODB_CLIENT_OPTIONS)
 
 
 class TestFTPModule(unittest.TestCase):
@@ -546,81 +502,6 @@ class TestMySQLModule(unittest.TestCase):
         self.assertEqual(log["logtype"], 9003)
         self.assertEqual(log["dst_port"], 3306)
         self.assertEqual(log["logdata"], {})
-
-
-class TestMongoDBModule(unittest.TestCase):
-    """
-    Tests the MongoDB server with a real MongoDB client.
-    """
-
-    def setUp(self):
-        self.log_start = get_log_count()
-        self.client = get_mongodb_client()
-
-    def test_mongodb_hello(self):
-        """
-        Connect to the MongoDB service and send a hello command.
-        """
-        response = self.client.admin.command("hello")
-
-        self.assertEqual(response["ok"], 1.0)
-        self.assertTrue(response["ismaster"])
-        self.assertEqual(response["version"], MONGODB_VERSION)
-
-        last_log = get_mongodb_log("mongodb.connection", self.log_start)
-        self.assertIsNotNone(last_log)
-        self.assertEqual(last_log["logtype"], 20001)
-        self.assertEqual(last_log["dst_port"], MONGODB_PORT)
-        self.assertEqual(last_log["logdata"]["action"], "mongodb.connection")
-
-    def test_mongodb_auth_attempt(self):
-        """
-        Try to authenticate to the MongoDB service.
-        """
-        self.client.close()
-        self.client = get_mongodb_client(
-            "mongodb://test_user:test_pass@localhost:27017/admin?"
-            "authMechanism=SCRAM-SHA-256"
-        )
-
-        with self.assertRaises(OperationFailure) as error:
-            self.client.admin.command("ping")
-
-        self.assertEqual(error.exception.code, MONGODB_AUTH_FAILED_CODE)
-        last_log = get_mongodb_log(
-            "mongodb.auth_attempt",
-            self.log_start,
-            {"username": "test_user", "mechanism": "SCRAM-SHA-256"},
-        )
-        self.assertIsNotNone(last_log)
-        self.assertEqual(last_log["logtype"], 20001)
-        self.assertEqual(last_log["dst_port"], MONGODB_PORT)
-        self.assertEqual(last_log["logdata"]["action"], "mongodb.auth_attempt")
-        self.assertEqual(last_log["logdata"]["username"], "test_user")
-        self.assertEqual(last_log["logdata"]["mechanism"], "SCRAM-SHA-256")
-        self.assertIn("payload", last_log["logdata"]["auth_data"])
-
-    def test_mongodb_command_attempt(self):
-        """
-        Try to run an unauthenticated MongoDB command.
-        """
-        with self.assertRaises(OperationFailure) as error:
-            self.client.admin.command("listDatabases")
-
-        self.assertEqual(error.exception.code, MONGODB_UNAUTHORIZED_CODE)
-
-        last_log = get_mongodb_log(
-            "mongodb.command", self.log_start, {"command": "listDatabases"}
-        )
-        self.assertIsNotNone(last_log)
-        self.assertEqual(last_log["logtype"], 20001)
-        self.assertEqual(last_log["dst_port"], MONGODB_PORT)
-        self.assertEqual(last_log["logdata"]["action"], "mongodb.command")
-        self.assertEqual(last_log["logdata"]["command"], "listDatabases")
-        self.assertIn("listDatabases", last_log["logdata"]["query"])
-
-    def tearDown(self):
-        self.client.close()
 
 
 class TestRDPModule(unittest.TestCase):

--- a/opencanary/test/test_mongodb.py
+++ b/opencanary/test/test_mongodb.py
@@ -1,0 +1,115 @@
+import pytest
+from pymongo import MongoClient
+from pymongo.errors import OperationFailure
+
+from helpers import get_log_count, get_matching_log
+
+
+MONGODB_PORT = 27017
+MONGODB_VERSION = "4.4.6"
+MONGODB_AUTH_FAILED_CODE = 18
+MONGODB_UNAUTHORIZED_CODE = 13
+MONGODB_CLIENT_OPTIONS = {
+    "serverSelectionTimeoutMS": 2000,
+    "connectTimeoutMS": 2000,
+    "socketTimeoutMS": 2000,
+    "directConnection": True,
+}
+
+
+def get_mongodb_client(uri="mongodb://localhost:27017"):
+    return MongoClient(uri, **MONGODB_CLIENT_OPTIONS)
+
+
+def get_mongodb_log(action, start_line, logdata=None):
+    logdata = logdata or {}
+
+    def is_matching_log(log):
+        if log["dst_port"] != MONGODB_PORT:
+            return False
+        if log["logdata"].get("action") != action:
+            return False
+        if not all(log["logdata"].get(k) == v for k, v in logdata.items()):
+            return False
+        return True
+
+    return get_matching_log(start_line, is_matching_log)
+
+
+@pytest.fixture
+def log_start():
+    return get_log_count()
+
+
+@pytest.fixture
+def mongodb_client():
+    client = get_mongodb_client()
+    yield client
+    client.close()
+
+
+def test_mongodb_hello(mongodb_client, log_start):
+    """
+    Connect to the MongoDB service and send a hello command.
+    """
+    response = mongodb_client.admin.command("hello")
+
+    assert response["ok"] == 1.0
+    assert response["ismaster"] is True
+    assert response["version"] == MONGODB_VERSION
+
+    last_log = get_mongodb_log("mongodb.connection", log_start)
+    assert last_log is not None
+    assert last_log["logtype"] == 20001
+    assert last_log["dst_port"] == MONGODB_PORT
+    assert last_log["logdata"]["action"] == "mongodb.connection"
+
+
+def test_mongodb_auth_attempt(log_start):
+    """
+    Try to authenticate to the MongoDB service.
+    """
+    client = get_mongodb_client(
+        "mongodb://test_user:test_pass@localhost:27017/admin?"
+        "authMechanism=SCRAM-SHA-256"
+    )
+
+    try:
+        with pytest.raises(OperationFailure) as error:
+            client.admin.command("ping")
+
+        assert error.value.code == MONGODB_AUTH_FAILED_CODE
+        last_log = get_mongodb_log(
+            "mongodb.auth_attempt",
+            log_start,
+            {"username": "test_user", "mechanism": "SCRAM-SHA-256"},
+        )
+        assert last_log is not None
+        assert last_log["logtype"] == 20001
+        assert last_log["dst_port"] == MONGODB_PORT
+        assert last_log["logdata"]["action"] == "mongodb.auth_attempt"
+        assert last_log["logdata"]["username"] == "test_user"
+        assert last_log["logdata"]["mechanism"] == "SCRAM-SHA-256"
+        assert "payload" in last_log["logdata"]["auth_data"]
+    finally:
+        client.close()
+
+
+def test_mongodb_command_attempt(mongodb_client, log_start):
+    """
+    Try to run an unauthenticated MongoDB command.
+    """
+    with pytest.raises(OperationFailure) as error:
+        mongodb_client.admin.command("listDatabases")
+
+    assert error.value.code == MONGODB_UNAUTHORIZED_CODE
+
+    last_log = get_mongodb_log(
+        "mongodb.command", log_start, {"command": "listDatabases"}
+    )
+    assert last_log is not None
+    assert last_log["logtype"] == 20001
+    assert last_log["dst_port"] == MONGODB_PORT
+    assert last_log["logdata"]["action"] == "mongodb.command"
+    assert last_log["logdata"]["command"] == "listDatabases"
+    assert "listDatabases" in last_log["logdata"]["query"]

--- a/opencanary/test/test_mongodb.py
+++ b/opencanary/test/test_mongodb.py
@@ -4,7 +4,6 @@ from pymongo.errors import OperationFailure
 
 from helpers import get_log_count, get_matching_log
 
-
 MONGODB_PORT = 27017
 MONGODB_VERSION = "4.4.6"
 MONGODB_AUTH_FAILED_CODE = 18


### PR DESCRIPTION
## Proposed changes

The firs of a couple of PR's to migrate the testing to pytest from the python unit test into a dedicated test file for each opencanary module in preparation of adding more testing.

This PR handles the mongodb tests

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
