### PR TITLE
Migrate docker stable build to use uv

### DIFF
--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -1,15 +1,16 @@
 FROM python:3.10-bookworm
 
+COPY --from=docker.io/astral/uv:0.11.7 /uv /uvx /bin/
+
 # Download cache lists and install minimal versions
 RUN apt-get update && apt-get -yq install --no-install-recommends \
 	# Required linux dependencies
-	sudo vim build-essential libssl-dev libffi-dev python-dev libpcap-dev && \
+	sudo vim build-essential libssl-dev libffi-dev libpcap-dev && \
 	# Remove cache lists and clean up anything not needed to minimize image size
 	apt-get autoremove -yq && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install required pip dependencies
-RUN pip install opencanary
-RUN pip install scapy pcapy-ng
+# Install pinned release from PyPI with optional dependencies for SNMP/packet capture
+RUN uv pip install --system "opencanary[required-for-snmp]"
 
 # Set the default application we are running
 ENTRYPOINT [ "opencanaryd" ]


### PR DESCRIPTION
## Proposed changes

After the project was migrated to use uv the docker builds has been failing. This PR fixes the docker latest build to make use of uv.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
