### PR TITLE
Migrate ftp tests to pytest

### DIFF
--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -14,7 +14,6 @@ Still this is a start.
 
 import time
 import json
-from ftplib import FTP, error_perm
 import unittest
 import socket
 import warnings  # Used in the TestSSHModule (see comment there)
@@ -44,52 +43,6 @@ def get_last_n_logs(n):
     last_n_lines = lines[-n:]
     deserialized_data = [json.loads(line) for line in last_n_lines]
     return deserialized_data
-
-
-class TestFTPModule(unittest.TestCase):
-    """
-    Tests the cases for the FTP module.
-
-    The FTP server should not allow logins and should log each attempt.
-    """
-
-    def setUp(self):
-        self.ftp = FTP("localhost")
-
-    def test_attempted_ftp_connection(self):
-        """
-        Try to connect to the FTP service should log the connection attempt.
-        """
-        self.assertRaises(error_perm, self.ftp.login)
-        log = get_last_n_logs(2)[0]
-        self.assertEqual(log["logtype"], 2001)
-        self.assertEqual(log["dst_port"], 21)
-        self.assertEqual(log["logdata"], {})
-
-    def test_anonymous_ftp(self):
-        """
-        Try to connect to the FTP service with no username or password.
-        """
-        self.assertRaises(error_perm, self.ftp.login)
-        log = get_last_log()
-        self.assertEqual(log["dst_port"], 21)
-        self.assertEqual(log["logdata"]["USERNAME"], "anonymous")
-        self.assertEqual(log["logdata"]["PASSWORD"], "anonymous@")
-
-    def test_authenticated_ftp(self):
-        """
-        Connect to the FTP service with a test username and password.
-        """
-        self.assertRaises(
-            error_perm, self.ftp.login, user="test_user", passwd="test_pass"
-        )
-        last_log = get_last_log()
-        self.assertEqual(last_log["dst_port"], 21)
-        self.assertEqual(last_log["logdata"]["USERNAME"], "test_user")
-        self.assertEqual(last_log["logdata"]["PASSWORD"], "test_pass")
-
-    def tearDown(self):
-        self.ftp.close()
 
 
 class TestHTTPModule(unittest.TestCase):

--- a/opencanary/test/test_ftp.py
+++ b/opencanary/test/test_ftp.py
@@ -1,0 +1,47 @@
+import pytest
+from ftplib import FTP, error_perm
+
+from helpers import get_last_log, get_last_n_logs
+
+
+@pytest.fixture
+def ftp_client():
+    ftp = FTP("localhost")
+    yield ftp
+    ftp.close()
+
+
+def test_attempted_ftp_connection(ftp_client):
+    """
+    Try to connect to the FTP service should log the connection attempt.
+    """
+    with pytest.raises(error_perm):
+        ftp_client.login()
+    log = get_last_n_logs(2)[0]
+    assert log["logtype"] == 2001
+    assert log["dst_port"] == 21
+    assert log["logdata"] == {}
+
+
+def test_anonymous_ftp(ftp_client):
+    """
+    Try to connect to the FTP service with no username or password.
+    """
+    with pytest.raises(error_perm):
+        ftp_client.login()
+    log = get_last_log()
+    assert log["dst_port"] == 21
+    assert log["logdata"]["USERNAME"] == "anonymous"
+    assert log["logdata"]["PASSWORD"] == "anonymous@"
+
+
+def test_authenticated_ftp(ftp_client):
+    """
+    Connect to the FTP service with a test username and password.
+    """
+    with pytest.raises(error_perm):
+        ftp_client.login(user="test_user", passwd="test_pass")
+    last_log = get_last_log()
+    assert last_log["dst_port"] == 21
+    assert last_log["logdata"]["USERNAME"] == "test_user"
+    assert last_log["logdata"]["PASSWORD"] == "test_pass"


### PR DESCRIPTION
## Proposed changes

Migrate the testing to pytest from the python unit test into a dedicated test file for each opencanary module in preparation of adding more testing.

This PR handles the ftp tests

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
