### PR TITLE
Migrate rdp test to pytest

### DIFF
--- a/opencanary/test/module_test.py
+++ b/opencanary/test/module_test.py
@@ -12,10 +12,8 @@ test the code directly rather than relying on the out put of logs.
 Still this is a start.
 """
 
-import time
 import json
 import unittest
-import socket
 
 # These libraries are only needed by the test suite and so aren't in the
 # OpenCanary requirements, there is a requirements.txt file in the tests folder
@@ -350,56 +348,6 @@ class TestMySQLModule(unittest.TestCase):
         self.assertEqual(log["logtype"], 9003)
         self.assertEqual(log["dst_port"], 3306)
         self.assertEqual(log["logdata"], {})
-
-
-class TestRDPModule(unittest.TestCase):
-    """
-    Tests the RDP Server
-    """
-
-    def test_rdp_with_user_cookie(self):
-        """
-        Login to the RDP server and pass the username in the connection request
-        """
-        self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.connection.connect(("localhost", 3389))
-        packet = b""
-        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
-        # TPKT details
-        packet += b"\x03\x00\x00\x33"
-        # ISO connection
-        packet += b"\x2e\xe0\x00\x00\x00\x00\x00"
-        # RDP Cookie
-        packet += b"Cookie: mstshash=test_rdp_user"
-        # Negotiation request
-        packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
-        self.connection.sendall(packet)
-        time.sleep(1)
-
-        last_log = get_last_log()
-        self.assertEqual(last_log["logdata"]["USERNAME"], "test_rdp_user")
-        self.assertEqual(last_log["dst_port"], 3389)
-
-    def test_rdp_connection_with_no_user_details(self):
-        """
-        Connect to the RDP server, but do not pass a username (e.g. namp scan)
-        """
-        self.connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.connection.connect(("localhost", 3389))
-        packet = b""
-        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
-        # TPKT details
-        packet += b"\x03\x00\x00\x13"
-        # ISO connection
-        packet += b"\x0e\xe0\x00\x00\x00\x00\x01"
-        # Negotiation request
-        packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
-        self.connection.sendall(packet)
-        time.sleep(1)
-
-        last_log = get_last_log()
-        self.assertEqual(last_log["logdata"]["USERNAME"], None)
-        self.assertEqual(last_log["dst_port"], 3389)
 
 
 if __name__ == "__main__":

--- a/opencanary/test/test_rdp.py
+++ b/opencanary/test/test_rdp.py
@@ -37,7 +37,7 @@ def test_rdp_with_user_cookie(rdp_connection):
 
 def test_rdp_connection_with_no_user_details(rdp_connection):
     """
-    Connect to the RDP server, but do not pass a username (e.g. namp scan)
+    Connect to the RDP server, but do not pass a username (e.g. nmap scan)
     """
     packet = b""
     # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3

--- a/opencanary/test/test_rdp.py
+++ b/opencanary/test/test_rdp.py
@@ -1,0 +1,55 @@
+import pytest
+import socket
+import time
+
+from helpers import get_last_log
+
+
+@pytest.fixture
+def rdp_connection():
+    connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    connection.connect(("localhost", 3389))
+    yield connection
+    connection.close()
+
+
+def test_rdp_with_user_cookie(rdp_connection):
+    """
+    Login to the RDP server and pass the username in the connection request
+    """
+    packet = b""
+    # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+    # TPKT details
+    packet += b"\x03\x00\x00\x33"
+    # ISO connection
+    packet += b"\x2e\xe0\x00\x00\x00\x00\x00"
+    # RDP Cookie
+    packet += b"Cookie: mstshash=test_rdp_user"
+    # Negotiation request
+    packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
+    rdp_connection.sendall(packet)
+    time.sleep(1)
+
+    last_log = get_last_log()
+    assert last_log["logdata"]["USERNAME"] == "test_rdp_user"
+    assert last_log["dst_port"] == 3389
+
+
+def test_rdp_connection_with_no_user_details(rdp_connection):
+    """
+    Connect to the RDP server, but do not pass a username (e.g. namp scan)
+    """
+    packet = b""
+    # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+    # TPKT details
+    packet += b"\x03\x00\x00\x13"
+    # ISO connection
+    packet += b"\x0e\xe0\x00\x00\x00\x00\x01"
+    # Negotiation request
+    packet += b"\x01\x00\x08\x00\x03\x00\x00\x00"
+    rdp_connection.sendall(packet)
+    time.sleep(1)
+
+    last_log = get_last_log()
+    assert last_log["logdata"]["USERNAME"] is None
+    assert last_log["dst_port"] == 3389


### PR DESCRIPTION
## Proposed changes

Migrate the testing to pytest from the python unit test into a dedicated test file for each opencanary module in preparation of adding more testing.

This PR handles the rdp tests

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
