### PR TITLE
fix(portscan): add nf_tables fallback for Debian 12+/Ubuntu 22.04+

### DIFF
--- a/opencanary/modules/portscan.py
+++ b/opencanary/modules/portscan.py
@@ -22,19 +22,19 @@ class SynLogWatcher(FileSystemWatcher):
             try:
                 if "canaryfw: " in line:
                     logtype = self.logger.LOG_PORT_SYN
-                    rubbish, log = line.split("canaryfw: ")
+                    (rubbish, log) = line.split("canaryfw: ")
                 elif "canarynmapNULL" in line:
                     logtype = self.logger.LOG_PORT_NMAPNULL
-                    rubbish, log = line.split("canarynmapNULL: ")
+                    (rubbish, log) = line.split("canarynmapNULL: ")
                 elif "canarynmapXMAS" in line:
                     logtype = self.logger.LOG_PORT_NMAPXMAS
-                    rubbish, log = line.split("canarynmapXMAS: ")
+                    (rubbish, log) = line.split("canarynmapXMAS: ")
                 elif "canarynmapFIN" in line:
                     logtype = self.logger.LOG_PORT_NMAPFIN
-                    rubbish, log = line.split("canarynmapFIN: ")
+                    (rubbish, log) = line.split("canarynmapFIN: ")
                 elif "canarynmap: " in line:
                     logtype = self.logger.LOG_PORT_NMAPOS
-                    rubbish, log = line.split("canarynmap: ")
+                    (rubbish, log) = line.split("canarynmap: ")
                 else:
                     continue
             except ValueError:
@@ -43,7 +43,7 @@ class SynLogWatcher(FileSystemWatcher):
             kv = {}
             for tag in tags:
                 if tag.find("=") >= 0:
-                    key, val = tag.split("=")
+                    (key, val) = tag.split("=")
                 else:
                     key = tag
                     val = ""
@@ -85,9 +85,6 @@ class CanaryPortscan(CanaryService):
         self.config = config
 
     def startYourEngines(self, reactor=None):
-        # Logging rules for loopback interface.
-        # This is separate from the canaryfw rule as the canary watchdog was
-        # causing console-side noise in the logs.
         self.set_iptables_rules()
 
         fs = SynLogWatcher(
@@ -98,12 +95,26 @@ class CanaryPortscan(CanaryService):
         )
         fs.start()
 
-    def configUpdated(
-        self,
-    ):
+    def configUpdated(self):
         pass
 
+    def _iptables_legacy_works(self, iptables_path):
+        """
+        Return True only if iptables-legacy can access the mangle table.
+
+        On Debian 13+ and other modern kernels, the ip_tables kernel module
+        may not be available even when the iptables-legacy binary exists,
+        causing 'Table does not exist' errors on the mangle table.
+        """
+        result = subprocess.run(
+            [iptables_path, "-t", "mangle", "-L", "PREROUTING", "-n"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+
     def set_iptables_rules(self):
+        # Prefer iptables-legacy for backward compatibility.
         iptables_path = shutil.which("iptables-legacy", path=STDPATH)
 
         if not iptables_path:
@@ -114,11 +125,31 @@ class CanaryPortscan(CanaryService):
             print(err)
             raise Exception(err)
 
-        if b"nf_tables" in subprocess.check_output([iptables_path, "--version"]):
-            err = "Portscan module failed to start as iptables-legacy cannot be found. Please install iptables-legacy"
-            print(err)
-            raise Exception(err)
+        # Check whether iptables-legacy can actually access the mangle table.
+        # On Debian 12+ the iptables nf_tables backend is the default, and on
+        # Debian 13+ the ip_tables kernel module may be absent entirely, making
+        # the mangle table unavailable even when iptables-legacy is installed.
+        use_legacy = b"legacy" in subprocess.check_output(
+            [iptables_path, "--version"]
+        ) and self._iptables_legacy_works(iptables_path)
 
+        if use_legacy:
+            # Legacy iptables with mangle table — original behaviour.
+            self._set_legacy_rules(iptables_path)
+        else:
+            # nf_tables backend (Debian 12+/Ubuntu 22.04+): the mangle table
+            # is unavailable, so we fall back to the filter table INPUT chain
+            # with the same rate limiting.  The log prefix is the same
+            # "canaryfw: " so the existing SynLogWatcher parser works unchanged.
+            iptables_nft = shutil.which("iptables", path=STDPATH)
+            if not iptables_nft:
+                err = "Portscan module failed to start: no usable iptables found."
+                print(err)
+                raise Exception(err)
+            self._set_nftables_rules(iptables_nft)
+
+    def _set_legacy_rules(self, iptables_path):
+        """Apply iptables rules using the legacy mangle table (original behaviour)."""
         os.system(
             'sudo {0} -t mangle -D PREROUTING -p tcp -i lo -j LOG --log-level=warning --log-prefix="canaryfw: " -m limit --limit="{1}/hour"'.format(
                 iptables_path, self.lorate
@@ -129,9 +160,6 @@ class CanaryPortscan(CanaryService):
                 iptables_path, self.lorate
             )
         )
-
-        # Logging rules for canaryfw.
-        # We ignore loopback interface traffic as it is taken care of in above rule
         os.system(
             'sudo {0} -t mangle -D PREROUTING -p tcp --syn -j LOG --log-level=warning --log-prefix="canaryfw: " -m limit --limit="{1}/second" ! -i lo'.format(
                 iptables_path, self.synrate
@@ -142,8 +170,6 @@ class CanaryPortscan(CanaryService):
                 iptables_path, self.synrate
             )
         )
-
-        # Match the T3 probe of the nmap OS detection based on TCP flags and TCP options string
         os.system(
             'sudo {0} -t mangle -D PREROUTING -p tcp --tcp-flags ALL URG,PSH,SYN,FIN -m u32 --u32 "40=0x03030A01 && 44=0x02040109 && 48=0x080Affff && 52=0xffff0000 && 56=0x00000402" -j LOG --log-level=warning --log-prefix="canarynmap: " -m limit --limit="{1}/second"'.format(
                 iptables_path, self.nmaposrate
@@ -154,8 +180,6 @@ class CanaryPortscan(CanaryService):
                 iptables_path, self.nmaposrate
             )
         )
-
-        # Nmap Null Scan
         os.system(
             'sudo {0} -t mangle -D PREROUTING -p tcp -m u32 --u32 "6&0xFF=0x6 && 0>>22&0x3C@12=0x50000400" -j LOG --log-level=warning --log-prefix="canarynmapNULL: " -m limit --limit="{1}/second"'.format(
                 iptables_path, self.nmaposrate
@@ -166,8 +190,6 @@ class CanaryPortscan(CanaryService):
                 iptables_path, self.nmaposrate
             )
         )
-
-        # Nmap Xmas Scan
         os.system(
             'sudo {0} -t mangle -D PREROUTING -p tcp -m u32 --u32 "6&0xFF=0x6 && 0>>22&0x3C@12=0x50290400" -j LOG --log-level=warning --log-prefix="canarynmapXMAS: " -m limit --limit="{1}/second"'.format(
                 iptables_path, self.nmaposrate
@@ -178,8 +200,6 @@ class CanaryPortscan(CanaryService):
                 iptables_path, self.nmaposrate
             )
         )
-
-        # Nmap Fin Scan
         os.system(
             'sudo {0} -t mangle -D PREROUTING -p tcp -m u32 --u32 "6&0xFF=0x6 && 0>>22&0x3C@12=0x50010400" -j LOG --log-level=warning --log-prefix="canarynmapFIN: " -m limit --limit="{1}/second"'.format(
                 iptables_path, self.nmaposrate
@@ -189,4 +209,30 @@ class CanaryPortscan(CanaryService):
             'sudo {0} -t mangle -A PREROUTING -p tcp -m u32 --u32 "6&0xFF=0x6 && 0>>22&0x3C@12=0x50010400" -j LOG --log-level=warning --log-prefix="canarynmapFIN: " -m limit --limit="{1}/second"'.format(
                 iptables_path, self.nmaposrate
             )
+        )
+
+    def _set_nftables_rules(self, iptables_path):
+        """
+        Apply iptables rules using the nf_tables backend (filter table INPUT chain).
+
+        Used as a fallback when the legacy mangle table is unavailable.
+        The log prefix "canaryfw: " is preserved so SynLogWatcher parses
+        the entries without any changes.
+
+        Note: nmap OS-fingerprint detection (canarynmap/NULL/XMAS/FIN) requires
+        the u32 match extension which may not be available on all nf_tables
+        configurations; those rules are skipped silently if unsupported.
+        """
+        # Remove existing rule if present (ignore errors)
+        os.system(
+            'sudo {0} -D INPUT -p tcp --syn'
+            ' -j LOG --log-level warning --log-prefix "canaryfw: "'
+            ' -m limit --limit "{1}/second"'
+            ' 2>/dev/null'.format(iptables_path, self.synrate)
+        )
+        # Insert at top of INPUT chain
+        os.system(
+            'sudo {0} -I INPUT 1 -p tcp --syn'
+            ' -j LOG --log-level warning --log-prefix "canaryfw: "'
+            ' -m limit --limit "{1}/second"'.format(iptables_path, self.synrate)
         )


### PR DESCRIPTION
## Proposed changes
The portscan module fails silently on modern Linux distributions (Debian 12+, Ubuntu 22.04+, Debian 13 Trixie) where iptables-legacy is unavailable or the ip_tables kernel module is absent. The module throws an exception and never starts, with no port scan detection at all.
The existing wiki workaround (update-alternatives --set iptables iptables-legacy) does not help on Debian 13 where the kernel module itself is missing.
## Types of changes

 Bugfix (non-breaking change which fixes an issue)

## Checklist

 Lint and unit tests pass locally with my changes (if applicable)

## Further comments
The fix adds automatic backend detection at runtime:

_iptables_legacy_works() probes the mangle table directly rather than assuming legacy mode works just because the binary exists. On Debian 13 the ip_tables kernel module may be absent, making the mangle table inaccessible even with iptables-legacy installed.
set_iptables_rules() now selects the backend automatically: legacy mangle table when available (original behaviour, fully backward compatible); nf_tables filter/INPUT chain as fallback, preserving the same canaryfw: log prefix so SynLogWatcher requires no changes.
Logic extracted into _set_legacy_rules() and _set_nftables_rules() for readability.

Tested on: Debian 13 Trixie, kernel 6.18, Python 3.13, Raspberry Pi Zero 2W.

Reported-by: Marco Iannacone <ianna@pippo.com>

