### PR TITLE
Fix HTTP proxy Basic Auth credential decoding

### DIFF
--- a/opencanary/modules/httpproxy.py
+++ b/opencanary/modules/httpproxy.py
@@ -70,7 +70,7 @@ class AlertProxyRequest(Request):
         atype, token = auth_arr
         if atype == "Basic":
             try:
-                username, password = b64decode(token).split(":")
+                username, password = b64decode(token).decode("utf-8").split(":", 1)
             except:  # noqa: E722
                 pass
         elif atype == "NTLM":

--- a/opencanary/test/test_httpproxy.py
+++ b/opencanary/test/test_httpproxy.py
@@ -47,3 +47,5 @@ def test_httpproxy_auth_attempt_is_logged():
     assert log["logtype"] == LoggerBase.LOG_HTTPPROXY_LOGIN_ATTEMPT
     assert "USERNAME" in log["logdata"]
     assert "PASSWORD" in log["logdata"]
+    assert log["logdata"]["USERNAME"] == "test_user"
+    assert log["logdata"]["PASSWORD"] == "test_pass"


### PR DESCRIPTION
## Summary

Fixes Basic Auth credential decoding in the HTTP proxy module.

`base64.b64decode()` returns bytes under Python 3, but the existing code splits with a string delimiter. That raises an exception, is swallowed, and causes valid Basic Auth credentials to be logged as `Invalid auth-token submitted`.

This PR:
- decodes the Basic Auth token before splitting
- splits on the first colon only, preserving passwords that contain `:`
- updates the HTTP proxy test to assert the captured username/password values

## Testing

- `uvx pre-commit run --all-files`
- `pytest opencanary/test/test_httpproxy.py -q`

For the pytest run I started a minimal local OpenCanary instance with only the HTTP proxy enabled and logging to `/var/tmp/opencanary.log`, matching the integration test expectation.
