### PR TITLE
docs: fix config file precedence order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ OpenCanary Docker images are hosted on Docker Hub. These are only useful on Linu
 
 When OpenCanary starts it looks for config files in the following locations and will stop when the first configuration is found:
 
-1. `./opencanary.conf` (i.e. the directory where OpenCanary is installed)
+1. `/etc/opencanaryd/opencanary.conf`
 2. `~/.opencanary.conf` (i.e. the home directory of the user, usually this will be `root` so `/root/.opencanary.conf`)
-3. `/etc/opencanaryd/opencanary.conf`
+3. `./opencanary.conf` (i.e. the directory where OpenCanary is installed)
 
 To create an initial configuration, run as `root` (you may be prompted for a `sudo` password):
 ```


### PR DESCRIPTION
_Disclosure: this patch was prepared with AI assistance (Claude Opus 5). I read the config loader myself to confirm the discrepancy before opening this._

### Problem

The README lists the config file search order as:

1. `./opencanary.conf`
2. `~/.opencanary.conf`
3. `/etc/opencanaryd/opencanary.conf`

`Config.__init__` in `opencanary/config.py` builds the candidate list in the opposite order and returns on the first file that loads:

```python
files = [
    "/etc/opencanaryd/%s" % configfile,
    "%s/.%s" % (expanduser("~"), configfile),
    configfile,
]
...
for fname in files:
    try:
        with open(fname, "r") as f:
            ...
            return
```

So `/etc/opencanaryd/opencanary.conf` actually wins, and `./opencanary.conf` is consulted last.

The same function also warns when it ends up using the current-directory file:

> `Warning, making use of the configuration file in the immediate directory is not recommended!`

which the old ordering contradicted by presenting that path as the primary one.

For a honeypot this is worth getting right — an operator editing `./opencanary.conf` while `/etc/opencanaryd/opencanary.conf` exists would be changing a file that is never read, and could believe services are configured differently than they are.

### Fix

Reorder the three list items to match the code. No wording changes beyond the reordering, and the parenthetical explanations stay attached to their paths.

This is consistent with the rest of the README, which already tells users that `opencanaryd --copyconfig` writes to `/etc/opencanaryd/opencanary.conf`.
