### PR TITLE
fix(httpproxy): log NTLM proxy-auth attempts instead of exiting

### DIFF
--- a/opencanary/modules/httpproxy.py
+++ b/opencanary/modules/httpproxy.py
@@ -74,12 +74,10 @@ class AlertProxyRequest(Request):
             except:  # noqa: E722
                 pass
         elif atype == "NTLM":
-            # b64decode returns bytes not str in python2
-            print(b64decode(token).decode("utf-8").split(":"))
-            exit(1)
-            print("something NTLM")
-            # Shouldn't this return something?
-            return
+            # An NTLM Proxy-Authorization header carries an NTLMSSP message, not a
+            # user:pass pair, so record the raw token and let the attempt be logged
+            # like the Basic branch above.
+            username, password = token, ""
 
         logdata = {"USERNAME": username, "PASSWORD": password}
         factory.log(logdata, transport=self.transport)

--- a/opencanary/test/test_httpproxy.py
+++ b/opencanary/test/test_httpproxy.py
@@ -47,3 +47,31 @@ def test_httpproxy_auth_attempt_is_logged():
     assert log["logtype"] == LoggerBase.LOG_HTTPPROXY_LOGIN_ATTEMPT
     assert "USERNAME" in log["logdata"]
     assert "PASSWORD" in log["logdata"]
+
+
+def test_httpproxy_ntlm_auth_attempt_is_logged():
+    """
+    Send a proxy request with an NTLM Proxy-Authorization header and verify the
+    attempt is logged. Regression test: the NTLM branch previously called
+    exit(1) before reaching factory.log, so NTLM probes were never alerted on.
+    """
+    log_start = get_log_count()
+    token = base64.b64encode(b"TlRMTVNTUAABAAAA").decode("ascii")
+
+    session = requests.Session()
+    session.trust_env = False
+    response = session.get(
+        "http://example.com/",
+        proxies={"http": f"http://localhost:{HTTPPROXY_PORT}"},
+        headers={"Proxy-Authorization": f"NTLM {token}"},
+        timeout=2,
+    )
+
+    assert response.status_code == 407
+
+    log = get_httpproxy_log(log_start)
+    assert log is not None
+    assert log["dst_port"] == HTTPPROXY_PORT
+    assert log["logtype"] == LoggerBase.LOG_HTTPPROXY_LOGIN_ATTEMPT
+    assert "USERNAME" in log["logdata"]
+    assert "PASSWORD" in log["logdata"]


### PR DESCRIPTION
_Disclosure: prepared with AI assistance (Claude Opus 5). I read the request handler and confirmed the NTLM path never reaches `factory.log` before opening this._

### Problem

The NTLM branch of `AlertProxyRequest.logAuth` (`opencanary/modules/httpproxy.py`) contains leftover debug code:

```python
elif atype == "NTLM":
    # b64decode returns bytes not str in python2
    print(b64decode(token).decode("utf-8").split(":"))
    exit(1)
    print("something NTLM")
    # Shouldn't this return something?
    return
```

`logAuth()` is called first thing in `process()`, so for any request carrying `Proxy-Authorization: NTLM <token>`:

- `factory.log(logdata, ...)` (the alert) is never reached — the honeypot **never records NTLM proxy-auth attempts**, a blind spot for a whole probe class.
- `exit(1)` raises `SystemExit`; Twisted isolates it per-connection (the daemon survives — verified on Twisted 26.4.0), but writes a full traceback to the operator's log on **every** such request. Invalid base64 hits the same path via an uncaught `binascii.Error` (the `Basic` branch has a `try/except`; this one does not).

PoC: `printf 'GET / HTTP/1.1\r\nHost: x\r\nProxy-Authorization: NTLM YTpi\r\n\r\n' | nc <honeypot> 8080` → traceback in the log, no alert.

### Fix

An NTLM `Proxy-Authorization` header carries an NTLMSSP message, not a `user:pass` pair. Record the raw token and fall through to the existing logging, like the `Basic` branch:

```python
elif atype == "NTLM":
    username, password = token, ""
```

### Verification

- `python -m py_compile` clean; traced that the NTLM branch now falls through to `factory.log` instead of `exit(1)`.
- Confirmed on Twisted 26.4.0 that the pre-fix `exit(1)` was caught per-connection (daemon survives) — the defect is the missing alert plus a per-request traceback, not a crash.
- Added `test_httpproxy_ntlm_auth_attempt_is_logged` in the existing integration-test style, to be run under the project's test harness alongside the other module tests.