### PR TITLE
fix(redis): build error messages without bytes.format (py3)

### DIFF
--- a/opencanary/modules/redis.py
+++ b/opencanary/modules/redis.py
@@ -9,14 +9,16 @@ import shlex
 
 class ProtocolError(Exception):
     def __init__(self, reason):
-        self.message = b"-ERR Protocol error: {reason}\r\n".format(reason=reason)
+        self.message = "-ERR Protocol error: {reason}\r\n".format(reason=reason).encode(
+            "utf-8"
+        )
 
 
 class ArgumentCountError(Exception):
     def __init__(self, cmd):
-        self.message = b"-ERR wrong number of arguments for '{cmd}' command\r\n".format(
+        self.message = "-ERR wrong number of arguments for '{cmd}' command\r\n".format(
             cmd=cmd.lower()
-        )
+        ).encode("utf-8")
 
 
 class AuthenticationRequiredError(Exception):


### PR DESCRIPTION
_Disclosure: prepared with AI assistance (Claude Opus 5), verified by constructing the exceptions directly._

### Problem

`ProtocolError` and `ArgumentCountError` (`opencanary/modules/redis.py`) build their message with `b"...".format(...)`, but **`bytes` has no `.format()` in Python 3**:

```python
class ProtocolError(Exception):
    def __init__(self, reason):
        self.message = b"-ERR Protocol error: {reason}\r\n".format(reason=reason)
```

So raising either exception throws `AttributeError: 'bytes' object has no attribute 'format'` from the constructor — which the `except (ProtocolError, ArgumentCountError, ...)` handler does not catch. Any malformed RESP input (an array element not starting with `$`, an invalid bulk length, etc.) triggers it. `UnknownCommandError` in the same file already does it the right way (`"...".format(...).encode("utf-8")`).

### Fix

Format as `str`, then `.encode("utf-8")`, matching `UnknownCommandError`.

### Verification

Constructing the exceptions directly (Python 3):

```
ProtocolError("invalid bulk length")  -> b'-ERR Protocol error: invalid bulk length\r\n'
ArgumentCountError("GET")             -> b"-ERR wrong number of arguments for 'get' command\r\n"
(old code) -> AttributeError: 'bytes' object has no attribute 'format'
```